### PR TITLE
🔧 fix: correct Docker Compose build context paths

### DIFF
--- a/docker/prod/services/docker-compose.yml
+++ b/docker/prod/services/docker-compose.yml
@@ -1,9 +1,9 @@
-version: "3.8"
+
 
 services:
   django:
     build:
-      context: ../../..
+      context: .
       dockerfile: docker/prod/Dockerfile
     restart: always
     ports:
@@ -21,7 +21,7 @@ services:
 
   db:
     build:
-      context: ../../..
+      context: .
       dockerfile: docker/postgis/Dockerfile
     restart: always
     environment:
@@ -44,7 +44,7 @@ services:
 
   beat:
     build:
-      context: ../../..
+      context: .
       dockerfile: docker/prod/Dockerfile
     restart: always
     command: uv run celery -A PharmacyOnDuty beat -l info --scheduler django_celery_beat.schedulers:DatabaseScheduler

--- a/docker/prod/workers/docker-compose.yml
+++ b/docker/prod/workers/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   worker:
     build:
-      context: ../../..
+      context: .
       dockerfile: docker/prod/Dockerfile
     restart: always
     command: uv run celery -A PharmacyOnDuty worker -l info --hostname=scraper@%%h

--- a/justfile
+++ b/justfile
@@ -31,44 +31,44 @@ dev-redis:
  
 # Production commands
 prod-up:
-    docker-compose -f docker-compose.prod.yml up -d
+    docker-compose -f docker/prod/services/docker-compose.yml --project-directory . up -d
     @echo "Production environment started"
  
 prod-down:
-    docker-compose -f docker-compose.prod.yml down
+    docker-compose -f docker/prod/services/docker-compose.yml --project-directory . down
     @echo "Production environment stopped"
  
 prod-logs:
-    docker-compose -f docker-compose.prod.yml logs -f
+    docker-compose -f docker/prod/services/docker-compose.yml --project-directory . logs -f
  
 prod-rebuild:
-    docker-compose -f docker-compose.prod.yml up --build -d
+    docker-compose -f docker/prod/services/docker-compose.yml --project-directory . up --build -d
     @echo "Production environment rebuilt and started"
  
 prod-django:
-    docker-compose -f docker-compose.prod.yml exec django bash
+    docker-compose -f docker/prod/services/docker-compose.yml --project-directory . exec django bash
  
 # Worker commands
 worker-up:
-    docker-compose -f docker-compose.worker.yml up -d
+    docker-compose -f docker/prod/workers/docker-compose.yml --project-directory . up -d
     @echo "Worker environment started"
  
 worker-down:
-    docker-compose -f docker-compose.worker.yml down
+    docker-compose -f docker/prod/workers/docker-compose.yml --project-directory . down
     @echo "Worker environment stopped"
  
 worker-logs:
-    docker-compose -f docker-compose.worker.yml logs -f
+    docker-compose -f docker/prod/workers/docker-compose.yml --project-directory . logs -f
  
 worker-rebuild:
-    docker-compose -f docker-compose.worker.yml up --build -d
+    docker-compose -f docker/prod/workers/docker-compose.yml --project-directory . up --build -d
     @echo "Worker environment rebuilt and started"
  
 # Utility commands
 clean:
     docker-compose -f docker/dev/docker-compose.yml --project-directory . down -v
-    docker-compose -f docker-compose.prod.yml down -v
-    docker-compose -f docker-compose.worker.yml down -v
+    docker-compose -f docker/prod/services/docker-compose.yml --project-directory . down -v
+    docker-compose -f docker/prod/workers/docker-compose.yml --project-directory . down -v
     @echo "WARNING: This will remove unused Docker containers, images, and networks."
     @echo "Images older than 24 hours will be removed. Recent images will be kept."
     @echo "This operation is less destructive than 'docker system prune -f'."
@@ -81,8 +81,8 @@ clean:
  
 ps:
     docker-compose -f docker/dev/docker-compose.yml --project-directory . ps
-    docker-compose -f docker-compose.prod.yml ps
-    docker-compose -f docker-compose.worker.yml ps
+    docker-compose -f docker/prod/services/docker-compose.yml --project-directory . ps
+    docker-compose -f docker/prod/workers/docker-compose.yml --project-directory . ps
  
 # Django management commands (dev)
 migrate:


### PR DESCRIPTION
## Summary
- Fix Docker build context paths for production deployments
- Align context resolution with Coolify's project-directory execution mode
- Update justfile commands to use correct compose file paths

## Changes
- Updated build context from `../../..` to `.` in production docker-compose files
- Fixed justfile paths to point to correct compose file locations in `docker/prod/`
- Removed obsolete `version` attribute from services compose file

## Impact
Resolves deployment failures in Coolify caused by incorrect path resolution when using `--project-directory .`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Reorganized production and worker Docker configurations to use centralized paths and improve build consistency.
  * Updated deployment commands for better maintainability while preserving existing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->