### PR TITLE
🔧 fix: resolve Docker permission errors with uv dependencies

### DIFF
--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -26,21 +26,21 @@ RUN groupadd -g 1000 python && \
 RUN mkdir -p /opt/venv /app/staticfiles /app/media && \
     chown -R python:python /opt/venv /app/staticfiles /app/media
 
-# Configure uv/venv for runtime (before switching user)
-ENV UV_PROJECT_ENVIRONMENT=/opt/venv
-ENV UV_COMPILE_BYTECODE=1
-ENV PATH=/opt/venv/bin:$PATH
-
 WORKDIR /app
 
 # Copy dependency files
 COPY pyproject.toml uv.lock ./
 
+# Switch to non-root user for security (before installing deps)
+USER python
+
+# Configure uv/venv for runtime (as non-root user)
+ENV UV_PROJECT_ENVIRONMENT=/opt/venv
+ENV UV_COMPILE_BYTECODE=1
+ENV PATH=/opt/venv/bin:$PATH
+
 # Install dependencies using UV (production - no dev dependencies)
 RUN uv sync --frozen --no-dev
-
-# Switch to non-root user for security
-USER python
 
 # Copy project files
 COPY --chown=python:python . .

--- a/docker/prod/services/docker-compose.yml
+++ b/docker/prod/services/docker-compose.yml
@@ -16,8 +16,8 @@ services:
       - CELERY_BROKER_URL=redis://:${REDIS_PASSWORD}@redis:6379/0
       - RUN_MIGRATIONS=true
     command: >
-      sh -c "uv run python manage.py collectstatic --noinput &&
-             uv run gunicorn PharmacyOnDuty.wsgi:application --bind 0.0.0.0:8000"
+      sh -c "uv run --no-dev python manage.py collectstatic --noinput &&
+             uv run --no-dev gunicorn PharmacyOnDuty.wsgi:application --bind 0.0.0.0:8000"
 
   db:
     build:
@@ -47,7 +47,7 @@ services:
       context: .
       dockerfile: docker/prod/Dockerfile
     restart: always
-    command: uv run celery -A PharmacyOnDuty beat -l info --scheduler django_celery_beat.schedulers:DatabaseScheduler
+    command: uv run --no-dev celery -A PharmacyOnDuty beat -l info --scheduler django_celery_beat.schedulers:DatabaseScheduler
     environment:
       - DB_HOST=db
       - CELERY_BROKER_URL=redis://:${REDIS_PASSWORD}@redis:6379/0

--- a/docker/prod/workers/docker-compose.yml
+++ b/docker/prod/workers/docker-compose.yml
@@ -4,6 +4,6 @@ services:
       context: .
       dockerfile: docker/prod/Dockerfile
     restart: always
-    command: uv run celery -A PharmacyOnDuty worker -l info --hostname=scraper@%%h
+    command: uv run --no-dev celery -A PharmacyOnDuty worker -l info --hostname=scraper@%%h
     environment:
       - DJANGO_SETTINGS_MODULE=PharmacyOnDuty.settings

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 # Only run migrations if explicitly requested
 if [ "$RUN_MIGRATIONS" = "true" ]; then
   echo "Running database migrations..."
-  uv run python manage.py migrate --noinput
+  uv run --no-dev python manage.py migrate --noinput
 fi
 
 echo "Executing Django command..."


### PR DESCRIPTION
## Summary
- Switch to non-root user before installing dependencies in Dockerfile to fix ownership issues
- Add --no-dev flag to all uv run commands to prevent automatic dev dependency installation at runtime
- Fix entrypoint script to use --no-dev for migrations
- Resolve "Permission denied (os error 13)" errors in Coolify worker deployments

This addresses the root cause of worker deployment failures where celery-types and mypy-extensions were trying to install as non-root user in directories owned by root.

## Files Changed
- `docker/prod/Dockerfile`: Reorder USER directive before dependency installation
- `docker/prod/services/docker-compose.yml`: Add --no-dev to django and beat commands
- `docker/prod/workers/docker-compose.yml`: Add --no-dev to worker command
- `scripts/entrypoint.sh`: Add --no-dev to migration command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized production deployment configuration to exclude development dependencies during application startup and migrations, enhancing production environment consistency and reducing overhead.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->