### PR TITLE
Shield: Fix CSRF vulnerability in pharmacy points endpoint

### DIFF
--- a/pharmacies/views.py
+++ b/pharmacies/views.py
@@ -16,7 +16,6 @@ from django.http import HttpRequest, HttpResponse, HttpResponseNotAllowed, JsonR
 from django.shortcuts import render
 from django.utils import timezone
 from django.views.decorators.cache import cache_page
-from django.views.decorators.csrf import csrf_exempt
 
 from pharmacies.models import City, PharmacyStatus
 from pharmacies.utils import (
@@ -30,7 +29,6 @@ TEST_TIME = timezone.now() + timedelta(hours=10)
 SHOWN_PHARMACIES = 5
 
 
-@csrf_exempt
 def get_pharmacy_points(request: HttpRequest) -> JsonResponse:
     """
     Handle POST requests to retrieve the nearest pharmacies based on user location.

--- a/theme/templates/pharmacies.html
+++ b/theme/templates/pharmacies.html
@@ -43,6 +43,7 @@
         <script src="https://hammerjs.github.io/dist/hammer.min.js"></script>
     </head>
     <body class="bg-gray-50 text-gray-900 min-h-screen flex flex-col">
+        <div style="display:none;">{% csrf_token %}</div>
         <main class="flex-1 flex flex-col bg-gray-50">
             <div class="flex items-center">
                 <div class="h-14 w-14 m-5 flex items-center bg-primary-100 rounded-l relative z-10 border-b border-neutral-400"
@@ -365,11 +366,11 @@
 			return cookieValue;
 		}
 
-		{% comment %} $.ajaxSetup({
+		$.ajaxSetup({
 			beforeSend: function (xhr, settings) {
 				xhr.setRequestHeader("X-CSRFToken", getCSRFToken());
 			}
-}); {% endcomment %}
+});
         </script>
         <script type="application/ld+json">
 		{


### PR DESCRIPTION
Removed `@csrf_exempt` from `get_pharmacy_points` in `pharmacies/views.py`.
Updated `theme/templates/pharmacies.html` to include `{% csrf_token %}` and send `X-CSRFToken` header in AJAX requests.

---
*PR created automatically by Jules for task [716259887771742436](https://jules.google.com/task/716259887771742436) started by @gidorah*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security by enforcing CSRF token protection on all requests, preventing unauthorized cross-site form submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->