### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix CSRF vulnerability in get_pharmacy_points

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-28 - [CRITICAL] Fix CSRF vulnerability in get_pharmacy_points
+**Vulnerability:** The `get_pharmacy_points` POST endpoint had CSRF protection disabled via the `@csrf_exempt` decorator, allowing Cross-Site Request Forgery attacks.
+**Learning:** This endpoint proxies paid Google Maps API requests, so bypassing CSRF allows attackers to potentially abuse the quota and steal funds. Furthermore, the frontend AJAX request lacked configuration to send the Django `csrftoken` back as a header, and the HTML template missed the `{% csrf_token %}` tag ensuring the cookie exists for anonymous users.
+**Prevention:** Always verify if an endpoint is mutating state or triggering paid services. In Django, do not indiscriminately use `@csrf_exempt`. Ensure frontend integrations use `$.ajaxSetup` to include the `X-CSRFToken` header from cookies, and include `{% csrf_token %}` in templates.

--- a/pharmacies/views.py
+++ b/pharmacies/views.py
@@ -16,7 +16,6 @@ from django.http import HttpRequest, HttpResponse, HttpResponseNotAllowed, JsonR
 from django.shortcuts import render
 from django.utils import timezone
 from django.views.decorators.cache import cache_page
-from django.views.decorators.csrf import csrf_exempt
 
 from pharmacies.models import City, PharmacyStatus
 from pharmacies.utils import (
@@ -30,7 +29,6 @@ TEST_TIME = timezone.now() + timedelta(hours=10)
 SHOWN_PHARMACIES = 5
 
 
-@csrf_exempt
 def get_pharmacy_points(request: HttpRequest) -> JsonResponse:
     """
     Handle POST requests to retrieve the nearest pharmacies based on user location.

--- a/theme/templates/pharmacies.html
+++ b/theme/templates/pharmacies.html
@@ -43,6 +43,7 @@
         <script src="https://hammerjs.github.io/dist/hammer.min.js"></script>
     </head>
     <body class="bg-gray-50 text-gray-900 min-h-screen flex flex-col">
+        {% csrf_token %}
         <main class="flex-1 flex flex-col bg-gray-50">
             <div class="flex items-center">
                 <div class="h-14 w-14 m-5 flex items-center bg-primary-100 rounded-l relative z-10 border-b border-neutral-400"
@@ -365,11 +366,11 @@
 			return cookieValue;
 		}
 
-		{% comment %} $.ajaxSetup({
+		$.ajaxSetup({
 			beforeSend: function (xhr, settings) {
 				xhr.setRequestHeader("X-CSRFToken", getCSRFToken());
 			}
-}); {% endcomment %}
+		});
         </script>
         <script type="application/ld+json">
 		{


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `get_pharmacy_points` POST API endpoint had CSRF protection disabled via the `@csrf_exempt` decorator. This endpoint does external calls to Google Maps API.
🎯 Impact: Attackers could potentially exploit this vulnerability to bypass CSRF, leading to an abuse of the API quota and financial loss for the application.
🔧 Fix: Removed the `@csrf_exempt` decorator. Re-enabled `$.ajaxSetup` in the frontend code to send the CSRF token and included `{% csrf_token %}` in the main HTML template body so Django sets the token for the user/session.
✅ Verification: Confirmed functionality via code review. Evaluated changes directly, as test suite failure is expected due to missing GDAL binaries in the sandbox.

---
*PR created automatically by Jules for task [13236993062033696823](https://jules.google.com/task/13236993062033696823) started by @gidorah*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened protection against unauthorized pharmacy requests through enhanced validation mechanisms.
  * Improved AJAX request security with token-based verification across the pharmacy interface.
  * Documented critical security vulnerability and recommended preventive measures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->