### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix CSRF Vulnerability on Pharmacy Points Endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-01-24 - [CRITICAL] Fix CSRF Vulnerability on Pharmacy Points Endpoint
+**Vulnerability:** The `get_pharmacy_points` POST endpoint in `pharmacies/views.py` was decorated with `@csrf_exempt`, disabling Django's Cross-Site Request Forgery (CSRF) protection.
+**Learning:** This endpoint accepts user location data and could have been exploited to force a user to perform unwanted actions or abuse quota for external APIs (like Google Maps integrations based on the coordinates). The frontend also had its CSRF AJAX setup commented out.
+**Prevention:** Remove `@csrf_exempt` from sensitive POST endpoints. Ensure `{% csrf_token %}` is included in Django templates (even if hidden) so the `csrftoken` cookie is set, and configure the frontend (e.g., `$.ajaxSetup` in jQuery) to include the `X-CSRFToken` header in all AJAX requests.

--- a/pharmacies/views.py
+++ b/pharmacies/views.py
@@ -16,7 +16,6 @@ from django.http import HttpRequest, HttpResponse, HttpResponseNotAllowed, JsonR
 from django.shortcuts import render
 from django.utils import timezone
 from django.views.decorators.cache import cache_page
-from django.views.decorators.csrf import csrf_exempt
 
 from pharmacies.models import City, PharmacyStatus
 from pharmacies.utils import (
@@ -30,7 +29,6 @@ TEST_TIME = timezone.now() + timedelta(hours=10)
 SHOWN_PHARMACIES = 5
 
 
-@csrf_exempt
 def get_pharmacy_points(request: HttpRequest) -> JsonResponse:
     """
     Handle POST requests to retrieve the nearest pharmacies based on user location.

--- a/theme/templates/pharmacies.html
+++ b/theme/templates/pharmacies.html
@@ -43,6 +43,7 @@
         <script src="https://hammerjs.github.io/dist/hammer.min.js"></script>
     </head>
     <body class="bg-gray-50 text-gray-900 min-h-screen flex flex-col">
+        <div style="display:none;">{% csrf_token %}</div>
         <main class="flex-1 flex flex-col bg-gray-50">
             <div class="flex items-center">
                 <div class="h-14 w-14 m-5 flex items-center bg-primary-100 rounded-l relative z-10 border-b border-neutral-400"
@@ -365,11 +366,11 @@
 			return cookieValue;
 		}
 
-		{% comment %} $.ajaxSetup({
+		$.ajaxSetup({
 			beforeSend: function (xhr, settings) {
 				xhr.setRequestHeader("X-CSRFToken", getCSRFToken());
 			}
-}); {% endcomment %}
+        });
         </script>
         <script type="application/ld+json">
 		{


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `get_pharmacy_points` POST endpoint in `pharmacies/views.py` was decorated with `@csrf_exempt`, disabling Django's Cross-Site Request Forgery (CSRF) protection. The frontend also had its CSRF AJAX setup commented out.
🎯 Impact: This endpoint accepts user location data. Lack of CSRF protection could allow an attacker to forge requests from authenticated users, potentially leading to unwanted actions or quota abuse on paid external APIs like Google Maps.
🔧 Fix: Removed `@csrf_exempt` from sensitive POST endpoints. Ensured `{% csrf_token %}` is included in the Django template so the `csrftoken` cookie is set for anonymous users, and configured the frontend (`$.ajaxSetup` in jQuery) to include the `X-CSRFToken` header in all AJAX requests.
✅ Verification: Ran `uv run python -m pytest` to ensure no functionality regressions occurred. Confirmed that the CSRF token is successfully injected and included in request headers. Added a learning log to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [7136025250580697381](https://jules.google.com/task/7136025250580697381) started by @gidorah*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened CSRF protection on the pharmacy points endpoint by enabling request validation for POST operations.
  * Improved CSRF token handling in AJAX requests to ensure proper security headers are transmitted.

* **Documentation**
  * Added documentation detailing CSRF vulnerability prevention and mitigation strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->