### PR TITLE
fix: harden scraper resilience

### DIFF
--- a/pharmacies/tasks.py
+++ b/pharmacies/tasks.py
@@ -5,14 +5,31 @@ This module defines background tasks for scraping pharmacy data from various sou
 and updating the database.
 """
 
+import logging
+from json import JSONDecodeError
+from typing import Any
+
 from celery import shared_task
+from django.db import close_old_connections, transaction
+from django.db.utils import InterfaceError
 from django.utils import timezone
+from requests.exceptions import RequestException
 
 from pharmacies.models import ScraperConfig
 from pharmacies.utils import (
     add_scraped_data_to_db,
     get_city_data,
 )
+
+logger = logging.getLogger(__name__)
+
+
+def _persist_scraped_data(city_data: list[dict[str, Any]], city_name: str) -> int:
+    with transaction.atomic():
+        add_scraped_data_to_db(city_data, city_name=city_name)
+        return ScraperConfig.objects.filter(city__name=city_name).update(
+            last_run=timezone.now()
+        )
 
 
 @shared_task
@@ -25,16 +42,41 @@ def run_scraper(city_name: str) -> None:
     2. Saves the scraped pharmacy data to the database.
     3. Updates the ScraperConfig's last_run timestamp.
     """
-    print(f"Running scraper for city {city_name}")
-    city_data = get_city_data(city_name=city_name)
-    print(f"Scraper for city {city_name} finished")
-    add_scraped_data_to_db(city_data, city_name=city_name)
-    print(f"Scraper data for city {city_name} saved to DB")
+    try:
+        close_old_connections()
+        print(f"Running scraper for city {city_name}")
+        city_data = get_city_data(city_name=city_name)
+        print(f"Scraper for city {city_name} finished")
+        if not city_data:
+            logger.warning(
+                "Scraper for city %s returned no data; skipping persistence update.",
+                city_name,
+            )
+            return
 
-    rows_updated = ScraperConfig.objects.filter(city__name=city_name).update(
-        last_run=timezone.now()
-    )
-    if rows_updated:
-        print(f"Scraper config for city {city_name} updated")
-    else:
-        print(f"No ScraperConfig found for city {city_name}")
+        close_old_connections()
+        try:
+            rows_updated = _persist_scraped_data(city_data, city_name)
+        except InterfaceError:
+            logger.warning(
+                "Retrying scraper persistence for city %s after a stale database connection.",
+                city_name,
+                exc_info=True,
+            )
+            close_old_connections()
+            rows_updated = _persist_scraped_data(city_data, city_name)
+
+        print(f"Scraper data for city {city_name} saved to DB")
+        if rows_updated:
+            print(f"Scraper config for city {city_name} updated")
+        else:
+            print(f"No ScraperConfig found for city {city_name}")
+    except (JSONDecodeError, RequestException):
+        logger.warning(
+            "Skipping scraper for city %s due to upstream fetch failure.",
+            city_name,
+            exc_info=True,
+        )
+        return
+    finally:
+        close_old_connections()

--- a/pharmacies/tests/test_ankara_scraper.py
+++ b/pharmacies/tests/test_ankara_scraper.py
@@ -1,5 +1,9 @@
 from datetime import UTC, datetime
+from json import JSONDecodeError
 from unittest.mock import MagicMock, patch
+
+import pytest
+from requests.exceptions import HTTPError
 
 from pharmacies.utils.ankaraeo_scraper import _get_duty_times, get_ankara_data
 
@@ -54,6 +58,7 @@ def test_get_ankara_data(mock_duty_times: MagicMock, mock_get: MagicMock) -> Non
     )
 
     mock_response = MagicMock()
+    mock_response.raise_for_status.return_value = None
 
     mock_response.json.return_value = {
         "NobetciEczaneBilgisiListesi": [
@@ -87,3 +92,46 @@ def test_get_ankara_data(mock_duty_times: MagicMock, mock_get: MagicMock) -> Non
     assert data[0]["duty_start"] == datetime(2025, 12, 16, 16, 0, tzinfo=UTC)
 
     assert data[0]["duty_end"] == datetime(2025, 12, 17, 6, 0, tzinfo=UTC)
+
+
+@patch("pharmacies.utils.ankaraeo_scraper.requests.get")
+def test_get_ankara_data_invalid_json(mock_get: MagicMock) -> None:
+    mock_response = MagicMock()
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.side_effect = JSONDecodeError("Expecting value", "", 0)
+    mock_get.return_value = mock_response
+
+    with pytest.raises(JSONDecodeError):
+        get_ankara_data()
+
+
+@patch("pharmacies.utils.ankaraeo_scraper.requests.get")
+def test_get_ankara_data_http_error(mock_get: MagicMock) -> None:
+    mock_response = MagicMock()
+    mock_response.raise_for_status.side_effect = HTTPError("boom")
+    mock_get.return_value = mock_response
+
+    with pytest.raises(HTTPError):
+        get_ankara_data()
+
+
+@patch("pharmacies.utils.ankaraeo_scraper.requests.get")
+def test_get_ankara_data_missing_pharmacy_list_returns_empty(
+    mock_get: MagicMock,
+) -> None:
+    mock_response = MagicMock()
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.return_value = {}
+    mock_get.return_value = mock_response
+
+    assert get_ankara_data() == []
+
+
+@patch("pharmacies.utils.ankaraeo_scraper.requests.get")
+def test_get_ankara_data_null_pharmacy_list_returns_empty(mock_get: MagicMock) -> None:
+    mock_response = MagicMock()
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.return_value = {"NobetciEczaneBilgisiListesi": None}
+    mock_get.return_value = mock_response
+
+    assert get_ankara_data() == []

--- a/pharmacies/tests/test_istanbul_scraper.py
+++ b/pharmacies/tests/test_istanbul_scraper.py
@@ -1,6 +1,9 @@
 from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
+import pytest
+from requests.exceptions import ConnectionError, HTTPError
+
 from pharmacies.utils.istanbul_saglik_scraper import (
     _get_coordinates_from_sehirharitasi_url,
     _get_duty_times,
@@ -43,7 +46,9 @@ def test_get_istanbul_data(mock_post: MagicMock) -> None:
     """
     mock_response = MagicMock()
     mock_response.status_code = 200
+    mock_response.raise_for_status.return_value = None
     mock_response.content = html_content.encode("utf-8")
+    mock_response.text = html_content
     mock_post.return_value = mock_response
 
     data = get_istanbul_data()
@@ -60,11 +65,39 @@ def test_get_istanbul_data(mock_post: MagicMock) -> None:
 @patch("pharmacies.utils.istanbul_saglik_scraper.DISTRICTS", ["Adalar"])
 def test_get_istanbul_data_failure(mock_post: MagicMock) -> None:
     mock_response = MagicMock()
-    mock_response.status_code = 500
+    mock_response.raise_for_status.side_effect = HTTPError("500")
     mock_post.return_value = mock_response
 
-    data = get_istanbul_data()
-    assert len(data) == 0
+    with pytest.raises(HTTPError):
+        get_istanbul_data()
+
+    mock_response.raise_for_status.assert_called_once()
+
+
+@patch("pharmacies.utils.istanbul_saglik_scraper.requests.post")
+@patch("pharmacies.utils.istanbul_saglik_scraper.DISTRICTS", ["Adalar", "Ataşehir"])
+def test_get_istanbul_data_raises_on_connection_error_after_partial_fetch(
+    mock_post: MagicMock,
+) -> None:
+    html_content = """
+    <div class="card">
+        <div class="card-header">Ignored</div>
+        <div class="card-header"><b>TEST ECZANESİ</b></div>
+        <label>Ignored</label>
+        <label><a href="tel:123456">123 456</a></label>
+        <i class="la la-home"></i><label>Test Address</label>
+        <a class="btn btn-primary btn-block" href="http://sehirharitasi.ibb.gov.tr/?lat=41.0&lon=28.9">Yol Tarifi</a>
+    </div>
+    """
+    mock_response = MagicMock()
+    mock_response.raise_for_status.return_value = None
+    mock_response.text = html_content
+    mock_post.side_effect = [mock_response, ConnectionError("down")]
+
+    with pytest.raises(ConnectionError):
+        get_istanbul_data()
+
+    assert mock_post.call_count == 2
 
 
 @patch("pharmacies.utils.istanbul_saglik_scraper.requests.post")
@@ -89,6 +122,8 @@ def test_get_istanbul_data_missing_tags(mock_post: MagicMock) -> None:
     mock_response = MagicMock()
     mock_response.status_code = 200
     mock_response.content = html_content.encode("utf-8")
+    mock_response.raise_for_status.return_value = None
+    mock_response.text = html_content
     mock_post.return_value = mock_response
 
     # Capture print output to verify warning
@@ -116,6 +151,8 @@ def test_get_istanbul_data_directions_list(mock_post: MagicMock) -> None:
     mock_response = MagicMock()
     mock_response.status_code = 200
     mock_response.content = html_content.encode("utf-8")
+    mock_response.raise_for_status.return_value = None
+    mock_response.text = html_content
     mock_post.return_value = mock_response
 
     # We need to mock BeautifulSoup behavior slightly if we want to test the list branch strictly,

--- a/pharmacies/tests/test_tasks.py
+++ b/pharmacies/tests/test_tasks.py
@@ -1,0 +1,139 @@
+from contextlib import nullcontext
+from json import JSONDecodeError
+from unittest.mock import MagicMock, patch
+
+from django.db.utils import InterfaceError
+from requests.exceptions import RequestException
+
+from pharmacies.tasks import run_scraper
+
+
+@patch("pharmacies.tasks.logger")
+@patch("pharmacies.tasks.close_old_connections")
+@patch("pharmacies.tasks._persist_scraped_data")
+@patch("pharmacies.tasks.get_city_data")
+def test_run_scraper_skips_persistence_on_upstream_json_error(
+    mock_get_city_data: MagicMock,
+    mock_persist: MagicMock,
+    mock_close_old_connections: MagicMock,
+    mock_logger: MagicMock,
+) -> None:
+    mock_get_city_data.side_effect = JSONDecodeError("Expecting value", "", 0)
+
+    run_scraper("ankara")
+
+    mock_persist.assert_not_called()
+    mock_logger.warning.assert_called_once()
+    assert mock_close_old_connections.call_count == 2
+
+
+@patch("pharmacies.tasks.logger")
+@patch("pharmacies.tasks.close_old_connections")
+@patch("pharmacies.tasks._persist_scraped_data")
+@patch("pharmacies.tasks.get_city_data")
+def test_run_scraper_skips_persistence_on_upstream_request_error(
+    mock_get_city_data: MagicMock,
+    mock_persist: MagicMock,
+    mock_close_old_connections: MagicMock,
+    mock_logger: MagicMock,
+) -> None:
+    mock_get_city_data.side_effect = RequestException("down")
+
+    run_scraper("istanbul")
+
+    mock_persist.assert_not_called()
+    mock_logger.warning.assert_called_once()
+    assert mock_close_old_connections.call_count == 2
+
+
+@patch("pharmacies.tasks.logger")
+@patch("pharmacies.tasks._persist_scraped_data")
+@patch("pharmacies.utils.istanbul_saglik_scraper.requests.post")
+@patch("pharmacies.utils.istanbul_saglik_scraper.DISTRICTS", ["Adalar"])
+def test_run_scraper_handles_istanbul_request_failures_through_dispatcher(
+    mock_post: MagicMock,
+    mock_persist: MagicMock,
+    mock_logger: MagicMock,
+) -> None:
+    mock_post.side_effect = RequestException("down")
+
+    run_scraper("istanbul")
+
+    mock_persist.assert_not_called()
+    mock_logger.warning.assert_called_once()
+
+
+@patch("pharmacies.tasks.logger")
+@patch("pharmacies.tasks.close_old_connections")
+@patch("pharmacies.tasks._persist_scraped_data")
+@patch("pharmacies.tasks.get_city_data")
+def test_run_scraper_skips_empty_scrapes(
+    mock_get_city_data: MagicMock,
+    mock_persist: MagicMock,
+    mock_close_old_connections: MagicMock,
+    mock_logger: MagicMock,
+) -> None:
+    mock_get_city_data.return_value = []
+
+    run_scraper("istanbul")
+
+    mock_persist.assert_not_called()
+    mock_logger.warning.assert_called_once()
+    assert mock_close_old_connections.call_count == 2
+
+
+@patch("pharmacies.tasks.logger")
+@patch("pharmacies.tasks.close_old_connections")
+@patch("pharmacies.tasks._persist_scraped_data")
+@patch("pharmacies.tasks.get_city_data")
+def test_run_scraper_retries_after_stale_db_connection(
+    mock_get_city_data: MagicMock,
+    mock_persist: MagicMock,
+    mock_close_old_connections: MagicMock,
+    mock_logger: MagicMock,
+) -> None:
+    mock_get_city_data.return_value = [{"name": "Example"}]
+    mock_persist.side_effect = [InterfaceError("connection already closed"), 1]
+
+    run_scraper("istanbul")
+
+    assert mock_persist.call_count == 2
+    mock_logger.warning.assert_called_once()
+    assert mock_close_old_connections.call_count == 4
+
+
+@patch("pharmacies.tasks.transaction.atomic")
+@patch("pharmacies.tasks.ScraperConfig.objects.filter")
+@patch("pharmacies.tasks.add_scraped_data_to_db")
+@patch("pharmacies.tasks.logger")
+def test_run_scraper_retries_real_persistence_helper_path(
+    mock_logger: MagicMock,
+    mock_add_scraped_data_to_db: MagicMock,
+    mock_filter: MagicMock,
+    mock_atomic: MagicMock,
+) -> None:
+    mock_atomic.return_value = nullcontext()
+    mock_filter.return_value.update.return_value = 1
+    scraped_data = [
+        {
+            "name": "Example Pharmacy",
+            "address": "Example Address",
+            "district": "Kadikoy",
+            "phone": "123456",
+            "coordinates": {"lat": 41.0, "lng": 28.9},
+            "duty_start": MagicMock(),
+            "duty_end": MagicMock(),
+        }
+    ]
+    mock_add_scraped_data_to_db.side_effect = [
+        InterfaceError("connection already closed"),
+        None,
+    ]
+
+    with patch("pharmacies.tasks.get_city_data", return_value=scraped_data):
+        run_scraper("istanbul")
+
+    assert mock_add_scraped_data_to_db.call_count == 2
+    mock_filter.assert_called_once_with(city__name="istanbul")
+    mock_filter.return_value.update.assert_called_once()
+    mock_logger.warning.assert_called_once()

--- a/pharmacies/utils/ankaraeo_scraper.py
+++ b/pharmacies/utils/ankaraeo_scraper.py
@@ -51,9 +51,10 @@ def get_ankara_data() -> list[dict[str, Any]]:
     today = datetime.now()
     url = base_url + today.strftime("%Y-%m-%d")
     response = requests.get(url, timeout=10)
+    response.raise_for_status()
 
     received_data = response.json()
-    received_pharmacy_list = received_data["NobetciEczaneBilgisiListesi"]
+    received_pharmacy_list = received_data.get("NobetciEczaneBilgisiListesi") or []
     duty_start, duty_end = _get_duty_times()
     pharmacies: list[dict[str, Any]] = []
     for pharmacy in received_pharmacy_list:

--- a/pharmacies/utils/istanbul_saglik_scraper.py
+++ b/pharmacies/utils/istanbul_saglik_scraper.py
@@ -125,14 +125,9 @@ def get_istanbul_data() -> list[dict[str, Any]]:
     for district_name in DISTRICTS:
         payload = {"ilce": district_name}
         response = requests.post(API_ENDPOINT, params=payload, timeout=10)
+        response.raise_for_status()
 
-        if response.status_code != 200:
-            print(
-                f"Error fetching data for district {district_name}: {response.status_code}"
-            )
-            continue
-
-        html_content = response.content.decode("utf-8")
+        html_content = response.text
         soup = BeautifulSoup(html_content, "html.parser")
         pharmacy_cards = soup.select(".card")
         for card in pharmacy_cards:


### PR DESCRIPTION
## Summary
- fail fast on Istanbul upstream request and HTTP errors so partial district scrapes are not persisted as successful city updates
- retry persistence once after stale database connections and skip persistence for empty or failed scrapes
- harden Ankara scraper response handling and add focused task and scraper regression coverage

## Validation
- uv run pytest pharmacies/tests/test_tasks.py pharmacies/tests/test_ankara_scraper.py pharmacies/tests/test_istanbul_scraper.py
- uv run ruff check pharmacies/tasks.py pharmacies/utils/ankaraeo_scraper.py pharmacies/utils/istanbul_saglik_scraper.py pharmacies/tests/test_tasks.py pharmacies/tests/test_ankara_scraper.py pharmacies/tests/test_istanbul_scraper.py
- uv run mypy pharmacies/tasks.py pharmacies/utils/ankaraeo_scraper.py pharmacies/utils/istanbul_saglik_scraper.py pharmacies/tests/test_tasks.py pharmacies/tests/test_ankara_scraper.py pharmacies/tests/test_istanbul_scraper.py
- live Postgres-backed retry verification against docker/dev PostGIS with a forced InterfaceError on the first persistence attempt

Closes #67
Closes #78

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for network failures during pharmacy data fetching
  * Added automatic retry logic for stale database connections
  * Enhanced graceful handling of missing or malformed data fields

* **Tests**
  * Expanded test coverage for error scenarios and edge cases to ensure reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->