### PR TITLE
fix: respect proxied HTTPS for CSRF checks

### DIFF
--- a/PharmacyOnDuty/settings.py
+++ b/PharmacyOnDuty/settings.py
@@ -58,7 +58,10 @@ CSRF_TRUSTED_ORIGINS = [
     if origin
 ]
 
-SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+enable_secure_proxy_ssl_header = os.environ.get("DJANGO_ENABLE_SECURE_PROXY_SSL_HEADER")
+SECURE_PROXY_SSL_HEADER = None
+if enable_secure_proxy_ssl_header == "True":
+    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 SECURE_SSL_REDIRECT = False
 

--- a/PharmacyOnDuty/settings.py
+++ b/PharmacyOnDuty/settings.py
@@ -58,6 +58,8 @@ CSRF_TRUSTED_ORIGINS = [
     if origin
 ]
 
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
 SECURE_SSL_REDIRECT = False
 
 # Application definition

--- a/pharmacies/tests/test_sentry_config.py
+++ b/pharmacies/tests/test_sentry_config.py
@@ -73,3 +73,37 @@ class SentryConfigTest(SimpleTestCase):
 
         self.assertFalse(settings_module.DEBUG)
         mock_init.assert_not_called()
+
+
+class SecureProxySslHeaderConfigTest(SimpleTestCase):
+    def tearDown(self) -> None:
+        importlib.reload(settings_module)
+
+    def test_secure_proxy_ssl_header_defaults_to_disabled_when_env_var_is_unset(
+        self,
+    ) -> None:
+        with patch.dict(os.environ, {"DJANGO_DEBUG": "False"}, clear=False):
+            os.environ.pop("DJANGO_ENABLE_SECURE_PROXY_SSL_HEADER", None)
+            os.environ.pop("SENTRY_DSN", None)
+            importlib.reload(settings_module)
+
+        self.assertIsNone(settings_module.SECURE_PROXY_SSL_HEADER)
+
+    def test_secure_proxy_ssl_header_enables_only_when_env_var_is_true(
+        self,
+    ) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "DJANGO_DEBUG": "False",
+                "DJANGO_ENABLE_SECURE_PROXY_SSL_HEADER": "True",
+            },
+            clear=False,
+        ):
+            os.environ.pop("SENTRY_DSN", None)
+            importlib.reload(settings_module)
+
+        self.assertEqual(
+            settings_module.SECURE_PROXY_SSL_HEADER,
+            ("HTTP_X_FORWARDED_PROTO", "https"),
+        )

--- a/pharmacies/tests/test_views.py
+++ b/pharmacies/tests/test_views.py
@@ -5,9 +5,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 from django.conf import settings
 from django.test import Client
+from django.test.utils import override_settings
 from django.urls import reverse
 
-from pharmacies.models import City, WorkingSchedule
+from pharmacies.models import City, PharmacyStatus, WorkingSchedule
 
 
 class TestGetPharmacyPointsNoDb:
@@ -175,3 +176,46 @@ class TestOtherViews:
         assert response.status_code == 200
         assert response.content == b"console.log('google maps');"
         assert response["Content-Type"] == "text/javascript"
+
+
+class TestProxyAwareCsrf:
+    @override_settings(ALLOWED_HOSTS=["eczanerede.com"])
+    @patch("pharmacies.views.City.objects.get")
+    @patch("pharmacies.views.get_city_name_from_location")
+    @patch("pharmacies.views.get_nearest_pharmacies_open")
+    def test_get_pharmacy_points_accepts_same_origin_https_behind_proxy(
+        self,
+        mock_fetch_open: MagicMock,
+        mock_get_city_name: MagicMock,
+        mock_get_city_record: MagicMock,
+    ) -> None:
+        client = Client(enforce_csrf_checks=True)
+        mock_city = MagicMock()
+        mock_city.get_city_status.return_value = PharmacyStatus.OPEN
+        mock_get_city_record.return_value = mock_city
+        mock_get_city_name.return_value = "eskisehir"
+        mock_fetch_open.return_value = [
+            {"title": "Open Pharmacy", "position": {"lat": 39.7, "lng": 30.5}}
+        ]
+
+        home_response = client.get(
+            reverse("home"),
+            HTTP_HOST="eczanerede.com",
+            HTTP_X_FORWARDED_PROTO="https",
+        )
+        csrf_token = home_response.cookies[settings.CSRF_COOKIE_NAME].value
+
+        with patch("django.utils.timezone.now") as mock_now:
+            mock_now.return_value = datetime(2025, 12, 16, 10, 0, tzinfo=UTC)
+            response = client.post(
+                reverse("pharmacies:get_pharmacy_points"),
+                data=json.dumps({"lat": 39.7, "lng": 30.5}),
+                content_type="application/json",
+                HTTP_HOST="eczanerede.com",
+                HTTP_ORIGIN="https://eczanerede.com",
+                HTTP_X_FORWARDED_PROTO="https",
+                HTTP_X_CSRFTOKEN=csrf_token,
+            )
+
+        assert response.status_code == 200
+        assert response.json()["points"][0]["title"] == "Open Pharmacy"

--- a/pharmacies/tests/test_views.py
+++ b/pharmacies/tests/test_views.py
@@ -179,7 +179,10 @@ class TestOtherViews:
 
 
 class TestProxyAwareCsrf:
-    @override_settings(ALLOWED_HOSTS=["eczanerede.com"])
+    @override_settings(
+        ALLOWED_HOSTS=["eczanerede.com"],
+        SECURE_PROXY_SSL_HEADER=("HTTP_X_FORWARDED_PROTO", "https"),
+    )
     @patch("pharmacies.views.City.objects.get")
     @patch("pharmacies.views.get_city_name_from_location")
     @patch("pharmacies.views.get_nearest_pharmacies_open")
@@ -203,6 +206,8 @@ class TestProxyAwareCsrf:
             HTTP_HOST="eczanerede.com",
             HTTP_X_FORWARDED_PROTO="https",
         )
+        assert home_response.status_code == 200
+        assert settings.CSRF_COOKIE_NAME in home_response.cookies
         csrf_token = home_response.cookies[settings.CSRF_COOKIE_NAME].value
 
         with patch("django.utils.timezone.now") as mock_now:

--- a/readme.md
+++ b/readme.md
@@ -584,6 +584,8 @@ This section explains how to run the application in a production setting using d
 
 The following environment variables are used to configure the application:
 
+- `DJANGO_ENABLE_SECURE_PROXY_SSL_HEADER`: Optional. Set it to the exact string `True` to enable proxy HTTPS detection when Django is running behind a trusted reverse proxy that overwrites `X-Forwarded-Proto` (for example Coolify). When unset or set to any other value, the setting stays disabled.
+
 | Variable Name             | Description                                                                                                                                                                                                                            | Default Value | Required |
 | :------------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------ | :------- |
 | `DJANGO_SECRET_KEY`       | A secret key used by Django for cryptographic signing. **This should be a long, random, and unpredictable value.**                                                                                                                   |               | Yes      |


### PR DESCRIPTION
## Summary
- trust `X-Forwarded-Proto` so Django recognizes HTTPS behind Coolify's reverse proxy
- add regression coverage for same-origin CSRF POST requests behind proxy TLS termination
- keep the CSRF failure reproducible in tests without requiring Postgres

## Problem
Production returned Django CSRF 403 responses for `POST /get_pharmacy_points` even though the homepage issued a CSRF cookie and the request was same-origin over HTTPS.

## Verification
- `uv run ruff check PharmacyOnDuty/settings.py pharmacies/tests/test_views.py`
- `uv run ruff format --check PharmacyOnDuty/settings.py pharmacies/tests/test_views.py`
- targeted pytest via VS Code test runner:
  - `test_pharmacies_list`
  - `test_get_pharmacy_points_requires_csrf`
  - `test_get_pharmacy_points_accepts_same_origin_https_behind_proxy`

## Notes
Coolify manages the production reverse proxy, so the fix relies on forwarded HTTPS scheme preservation rather than the repository nginx config.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added optional proxy-aware HTTPS detection controlled by an environment flag; disabled by default unless explicitly enabled.

* **Tests**
  * Added tests covering CSRF behavior when requests come through a proxy and tests verifying the proxy-aware setting toggles correctly.

* **Documentation**
  * Documented the new optional environment flag and its intended usage behind a trusted reverse proxy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->