### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix API Key Leak in Maps Proxy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Empty string default in `os.environ.get("ALLOWED_REFERERS", " ").split(" ")` resulted in an empty string in the allowed referers list. Any string `.startswith("")` evaluates to True, causing the `is_allowed_referer` check to pass unconditionally.
 **Learning:** Defaulting to a single space `" "` and splitting by `" "` yields `['', '']`. Empty strings in security allow-lists that use `startswith()` checks or exact matches are extremely dangerous and can completely nullify the security controls.
 **Prevention:** Always filter out empty strings after splitting environment variable strings, e.g., `[x for x in env.split(" ") if x]`.
+
+## 2025-05-24 - [API Key Leak via requests Exception Logging in Proxy]
+**Vulnerability:** The `google_maps_proxy` view caught `requests.exceptions.RequestException` and returned `str(e)` in a 500 JSON response. The exception string from `requests` often includes the full URL, which contained `settings.GOOGLE_MAPS_API_KEY` in the query string, exposing the secret API key to users if the proxy failed (e.g. network timeout).
+**Learning:** Returning or logging the raw string representation of third-party HTTP client exceptions (like `requests`) can inadvertently leak sensitive query parameters or authorization headers included in the failed request.
+**Prevention:** Always return generic error messages to the client and scrub sensitive information before logging exceptions, or rely on proper server-side loggers instead of returning raw exception strings in API responses.

--- a/pharmacies/views.py
+++ b/pharmacies/views.py
@@ -9,6 +9,7 @@ This module handles the HTTP requests for pharmacy data, including:
 
 from datetime import timedelta
 from json import JSONDecodeError, loads
+import traceback
 
 import requests
 from django.conf import settings
@@ -133,7 +134,9 @@ def google_maps_proxy(request: HttpRequest) -> HttpResponse | JsonResponse:
         response = requests.get(endpoint, params=params, timeout=10)
         return HttpResponse(response.text, content_type="text/javascript")
     except requests.exceptions.RequestException as e:
-        return JsonResponse({"error": str(e)}, status=500)
+        # Avoid returning str(e) as it can leak the Google Maps API key in the URL.
+        traceback.print_exc()
+        return JsonResponse({"error": "Failed to proxy request."}, status=500)
 
 
 def pharmacies_list(request: HttpRequest) -> HttpResponse:


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `google_maps_proxy` view caught `requests.exceptions.RequestException` and returned `str(e)` in a 500 JSON response. The exception string from `requests` often includes the full URL, which contained `settings.GOOGLE_MAPS_API_KEY` in the query string, exposing the secret API key to users if the proxy failed.
🎯 Impact: An attacker could force a failure (e.g. timeout) and receive the API key in the response string, gaining the ability to spoof requests and rack up cloud charges.
🔧 Fix: Changed error handling in `google_maps_proxy` to log the traceback locally using `traceback.print_exc()` and return a generic `"Failed to proxy request."` string to the client. Also added this critical learning to the `.jules/sentinel.md` journal.
✅ Verification: Ran `export DJANGO_SECRET_KEY="test" && uv run pytest pharmacies/tests/` to verify tests passed without introducing regression issues.

---
*PR created automatically by Jules for task [2546872152892020162](https://jules.google.com/task/2546872152892020162) started by @gidorah*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in proxy requests to return generic error messages instead of raw exception details, preventing accidental exposure of sensitive information (such as API keys) to clients.

* **Documentation**
  * Added security guidance documenting API key exposure risks and prevention strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->