### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix API Key Leak in Google Maps Proxy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Empty string default in `os.environ.get("ALLOWED_REFERERS", " ").split(" ")` resulted in an empty string in the allowed referers list. Any string `.startswith("")` evaluates to True, causing the `is_allowed_referer` check to pass unconditionally.
 **Learning:** Defaulting to a single space `" "` and splitting by `" "` yields `['', '']`. Empty strings in security allow-lists that use `startswith()` checks or exact matches are extremely dangerous and can completely nullify the security controls.
 **Prevention:** Always filter out empty strings after splitting environment variable strings, e.g., `[x for x in env.split(" ") if x]`.
+
+## 2026-04-11 - [Sensitive Data Leak via Raw Exception Strings in HTTP Clients]
+**Vulnerability:** In `google_maps_proxy`, returning `str(e)` on `requests.exceptions.RequestException` exposed the full request URL, including sensitive query parameters like the `GOOGLE_MAPS_API_KEY`.
+**Learning:** External API errors often embed sensitive context in exception messages. Directly passing these to API consumers leaks credentials, structure, and internal data.
+**Prevention:** Never return raw exception strings from HTTP clients to the end user. Catch exceptions, log them server-side for debugging, and return a sanitized, generic error message (e.g., `An error occurred while communicating with the Maps API.`).

--- a/pharmacies/tests/test_input_validation.py
+++ b/pharmacies/tests/test_input_validation.py
@@ -36,9 +36,9 @@ def test_invalid_coordinates(
     with patch("pharmacies.views.get_nearest_pharmacies_open", return_value=[]):
         response = get_pharmacy_points(request)
 
-    assert (
-        response.status_code == 400
-    ), f"Expected 400 for invalid lat, got {response.status_code}"
+    assert response.status_code == 400, (
+        f"Expected 400 for invalid lat, got {response.status_code}"
+    )
     # The error message content checking is what we want to verify
     assert b"Invalid coordinates" in response.content
 

--- a/pharmacies/views.py
+++ b/pharmacies/views.py
@@ -7,6 +7,7 @@ This module handles the HTTP requests for pharmacy data, including:
 - Proxying requests to the Google Maps API.
 """
 
+import logging
 from datetime import timedelta
 from json import JSONDecodeError, loads
 
@@ -133,7 +134,12 @@ def google_maps_proxy(request: HttpRequest) -> HttpResponse | JsonResponse:
         response = requests.get(endpoint, params=params, timeout=10)
         return HttpResponse(response.text, content_type="text/javascript")
     except requests.exceptions.RequestException as e:
-        return JsonResponse({"error": str(e)}, status=500)
+        logger = logging.getLogger(__name__)
+        logger.error("Failed to proxy request to Google Maps API: %s", e)
+        return JsonResponse(
+            {"error": "An error occurred while communicating with the Maps API."},
+            status=500,
+        )
 
 
 def pharmacies_list(request: HttpRequest) -> HttpResponse:

--- a/test_req.py
+++ b/test_req.py
@@ -1,0 +1,10 @@
+import requests
+
+try:
+    requests.get(
+        "https://nonexistent.maps.googleapis.com/maps/api/js",
+        params={"key": "SECRET_KEY_123"},
+        timeout=0.01,
+    )
+except Exception as e:
+    print("EXCEPTION:", str(e))

--- a/tests/test_location_coverage.py
+++ b/tests/test_location_coverage.py
@@ -70,46 +70,46 @@ class TestLocationCoverage:
             )
             duration = (time.time() - start_time) * 1000
 
-            assert (
-                duration < 500
-            ), f"Slow response for {scenario['description']}: {duration:.2f}ms"
+            assert duration < 500, (
+                f"Slow response for {scenario['description']}: {duration:.2f}ms"
+            )
 
             if scenario["expected_behavior"] == "should_return_pharmacy":
-                assert (
-                    response.status_code == 200
-                ), f"Failed for {scenario['description']} (Expected 200, got {response.status_code})"
+                assert response.status_code == 200, (
+                    f"Failed for {scenario['description']} (Expected 200, got {response.status_code})"
+                )
                 data = response.json()
-                assert (
-                    "points" in data
-                ), f"No points returned for {scenario['description']}"
+                assert "points" in data, (
+                    f"No points returned for {scenario['description']}"
+                )
                 points = data["points"]
-                assert (
-                    len(points) > 0
-                ), f"Empty points list for {scenario['description']}"
+                assert len(points) > 0, (
+                    f"Empty points list for {scenario['description']}"
+                )
 
                 prev_distance = -1
                 for point in points:
-                    assert (
-                        "travel_distance" in point
-                    ), f"Missing travel_distance in {point}"
-                    assert (
-                        "travel_duration" in point
-                    ), f"Missing travel_duration in {point}"
+                    assert "travel_distance" in point, (
+                        f"Missing travel_distance in {point}"
+                    )
+                    assert "travel_duration" in point, (
+                        f"Missing travel_duration in {point}"
+                    )
 
                     curr_distance = point["travel_distance"]
-                    assert (
-                        curr_distance >= prev_distance
-                    ), f"Points not sorted by distance for {scenario['description']}"
+                    assert curr_distance >= prev_distance, (
+                        f"Points not sorted by distance for {scenario['description']}"
+                    )
                     prev_distance = curr_distance
             else:
                 # For scenarios not marked as 'should_return_pharmacy', we expect a 400 Bad Request
                 # because get_city_name_from_location will raise ValueError for unknown/out-of-scope locations,
                 # or City.DoesNotExist will be raised.
-                assert (
-                    response.status_code == 400
-                ), f"Expected 400 for {scenario['description']} but got {response.status_code}"
+                assert response.status_code == 400, (
+                    f"Expected 400 for {scenario['description']} but got {response.status_code}"
+                )
 
                 data = response.json()
-                assert (
-                    "error" in data
-                ), f"Missing error message for {scenario['description']}"
+                assert "error" in data, (
+                    f"Missing error message for {scenario['description']}"
+                )


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `google_maps_proxy` view returned the raw exception string (`str(e)`) to the client when a `requests.exceptions.RequestException` occurred.
🎯 **Impact:** Exposing the raw exception string leaked the full request URL, which included sensitive query parameters such as the `GOOGLE_MAPS_API_KEY`. Attackers could force an error (e.g., via timeout or DNS failure if under their control) or simply wait for a transient failure to harvest the API key.
🔧 **Fix:** Replaced returning `str(e)` with standard Python `logging`. The exception is now logged server-side using `logger.error`, and a generic, safe JSON error message is returned to the client instead.
✅ **Verification:** Verified that standard linters pass (`ruff check`, `ruff format`). Tested manually via a simple python script to verify that requests exceptions naturally include the full URL.

*Also added a new critical learning entry to `.jules/sentinel.md` to prevent this pattern from recurring.*

---
*PR created automatically by Jules for task [12528196825009102880](https://jules.google.com/task/12528196825009102880) started by @gidorah*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Error messages now display generic user-friendly text instead of technical exception details.

* **Tests**
  * Added new test coverage for request scenarios and reformatted test assertions for consistency.

* **Documentation**
  * Updated documentation of error handling improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->