### PR TITLE
🔒 security: harden Django transport settings (HSTS, secure cookies, dev-only browser reload)

### DIFF
--- a/PharmacyOnDuty/settings.py
+++ b/PharmacyOnDuty/settings.py
@@ -58,11 +58,6 @@ CSRF_TRUSTED_ORIGINS = [
     if origin
 ]
 
-enable_secure_proxy_ssl_header = os.environ.get("DJANGO_ENABLE_SECURE_PROXY_SSL_HEADER")
-SECURE_PROXY_SSL_HEADER = None
-if enable_secure_proxy_ssl_header == "True":
-    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
-
 
 def _env_bool(name: str, default: bool) -> bool:
     """Parse a boolean environment variable, defaulting to ``default`` when unset."""
@@ -71,6 +66,10 @@ def _env_bool(name: str, default: bool) -> bool:
         return default
     return raw.strip().lower() in {"1", "true", "yes", "on"}
 
+
+SECURE_PROXY_SSL_HEADER: tuple[str, str] | None = None
+if _env_bool("DJANGO_ENABLE_SECURE_PROXY_SSL_HEADER", default=False):
+    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 # HTTPS / transport security. Defaults are safe for production (DEBUG=False).
 # When DEBUG is enabled the secure-cookie / HSTS / redirect knobs are

--- a/PharmacyOnDuty/settings.py
+++ b/PharmacyOnDuty/settings.py
@@ -63,7 +63,31 @@ SECURE_PROXY_SSL_HEADER = None
 if enable_secure_proxy_ssl_header == "True":
     SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
-SECURE_SSL_REDIRECT = False
+
+def _env_bool(name: str, default: bool) -> bool:
+    """Parse a boolean environment variable, defaulting to ``default`` when unset."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+# HTTPS / transport security. Defaults are safe for production (DEBUG=False).
+# When DEBUG is enabled the secure-cookie / HSTS / redirect knobs are
+# automatically disabled so local development over plain HTTP keeps working.
+SECURE_SSL_REDIRECT = _env_bool("DJANGO_SECURE_SSL_REDIRECT", default=not DEBUG)
+SESSION_COOKIE_SECURE = _env_bool("DJANGO_SESSION_COOKIE_SECURE", default=not DEBUG)
+CSRF_COOKIE_SECURE = _env_bool("DJANGO_CSRF_COOKIE_SECURE", default=not DEBUG)
+
+# HSTS: opt-in via env var so operators can ramp up the max-age safely.
+# Defaults to one year in production and 0 (disabled) in DEBUG.
+SECURE_HSTS_SECONDS = int(
+    os.environ.get("DJANGO_SECURE_HSTS_SECONDS", "0" if DEBUG else "31536000")
+)
+SECURE_HSTS_INCLUDE_SUBDOMAINS = _env_bool(
+    "DJANGO_SECURE_HSTS_INCLUDE_SUBDOMAINS", default=not DEBUG
+)
+SECURE_HSTS_PRELOAD = _env_bool("DJANGO_SECURE_HSTS_PRELOAD", default=False)
 
 # Application definition
 
@@ -78,7 +102,6 @@ INSTALLED_APPS = [
     "pharmacies",
     "theme",
     "tailwind",
-    "django_browser_reload",
     "django.contrib.sitemaps",
     "django_celery_beat",
     "django_celery_results",
@@ -96,8 +119,13 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "django_browser_reload.middleware.BrowserReloadMiddleware",
 ]
+
+# django-browser-reload is a development-only helper. Loading its app and
+# middleware in production is unnecessary attack surface.
+if DEBUG:
+    INSTALLED_APPS.append("django_browser_reload")
+    MIDDLEWARE.append("django_browser_reload.middleware.BrowserReloadMiddleware")
 
 ROOT_URLCONF = "PharmacyOnDuty.urls"
 

--- a/PharmacyOnDuty/urls.py
+++ b/PharmacyOnDuty/urls.py
@@ -17,6 +17,7 @@ Including another URLconf
 
 from typing import Any
 
+from django.conf import settings
 from django.contrib import admin
 from django.contrib.sitemaps.views import sitemap
 from django.urls import include, path
@@ -32,7 +33,6 @@ urlpatterns: list[Any] = [
     path("admin/", admin.site.urls),
     path("", include("pharmacies.urls")),
     path("", TemplateView.as_view(template_name="pharmacies.html"), name="home"),
-    path("__reload__/", include("django_browser_reload.urls")),
     path(
         "sitemap.xml",
         sitemap,
@@ -63,3 +63,8 @@ urlpatterns: list[Any] = [
         name="cookie_policy",
     ),
 ]
+
+# django-browser-reload is only mounted when DEBUG is enabled to keep the
+# development helper out of production routing.
+if settings.DEBUG:
+    urlpatterns.append(path("__reload__/", include("django_browser_reload.urls")))

--- a/docker/prod/services/docker-compose.yml
+++ b/docker/prod/services/docker-compose.yml
@@ -13,6 +13,16 @@ services:
       - DJANGO_DEBUG=False
       - CELERY_BROKER_URL=redis://:${REDIS_PASSWORD}@redis:6379/0
       - RUN_MIGRATIONS=true
+      # Coolify terminates TLS and forwards plain HTTP; Django must trust
+      # X-Forwarded-Proto or SECURE_SSL_REDIRECT will loop.
+      - DJANGO_ENABLE_SECURE_PROXY_SSL_HEADER=True
+      # Ramp up HSTS over time (3600 → 86400 → 604800 → 2592000 → 31536000).
+      - DJANGO_SECURE_HSTS_SECONDS=${DJANGO_SECURE_HSTS_SECONDS:-3600}
+      - DJANGO_SECURE_HSTS_INCLUDE_SUBDOMAINS=${DJANGO_SECURE_HSTS_INCLUDE_SUBDOMAINS:-True}
+      - DJANGO_SECURE_HSTS_PRELOAD=${DJANGO_SECURE_HSTS_PRELOAD:-False}
+      - DJANGO_SECURE_SSL_REDIRECT=${DJANGO_SECURE_SSL_REDIRECT:-True}
+      - DJANGO_SESSION_COOKIE_SECURE=${DJANGO_SESSION_COOKIE_SECURE:-True}
+      - DJANGO_CSRF_COOKIE_SECURE=${DJANGO_CSRF_COOKIE_SECURE:-True}
     command: >
       sh -c "uv run --no-dev python manage.py collectstatic --noinput &&
              uv run --no-dev gunicorn PharmacyOnDuty.wsgi:application --bind 0.0.0.0:8000"

--- a/readme.md
+++ b/readme.md
@@ -584,7 +584,7 @@ This section explains how to run the application in a production setting using d
 
 The following environment variables are used to configure the application:
 
-- `DJANGO_ENABLE_SECURE_PROXY_SSL_HEADER`: Optional. Set it to the exact string `True` to enable proxy HTTPS detection when Django is running behind a trusted reverse proxy that overwrites `X-Forwarded-Proto` (for example Coolify). When unset or set to any other value, the setting stays disabled.
+- `DJANGO_ENABLE_SECURE_PROXY_SSL_HEADER`: Optional. Set to any truthy value (`True`, `1`, `yes`, `on` — case-insensitive) to enable proxy HTTPS detection when Django is running behind a trusted reverse proxy that overwrites `X-Forwarded-Proto` (for example Coolify). When unset or set to a falsy value, the setting stays disabled. **Required in production** when `SECURE_SSL_REDIRECT` is enabled behind a TLS-terminating proxy, otherwise requests will redirect in a loop.
 
 | Variable Name             | Description                                                                                                                                                                                                                            | Default Value | Required |
 | :------------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------ | :------- |


### PR DESCRIPTION
## Summary

Hardens `PharmacyOnDuty/settings.py` so the deploy checklist (`python manage.py check --deploy`) is clean for production while keeping local dev unchanged.

### What changes

- **HTTPS / cookies / HSTS** are now controlled by env vars and default to **safe values whenever `DEBUG=False`**:
  | Setting | Old | New default (DEBUG=False) | Env var |
  | --- | --- | --- | --- |
  | `SECURE_SSL_REDIRECT` | `False` (hardcoded) | `True` | `DJANGO_SECURE_SSL_REDIRECT` |
  | `SESSION_COOKIE_SECURE` | unset → `False` | `True` | `DJANGO_SESSION_COOKIE_SECURE` |
  | `CSRF_COOKIE_SECURE` | unset → `False` | `True` | `DJANGO_CSRF_COOKIE_SECURE` |
  | `SECURE_HSTS_SECONDS` | unset → `0` | `31536000` (1 year) | `DJANGO_SECURE_HSTS_SECONDS` |
  | `SECURE_HSTS_INCLUDE_SUBDOMAINS` | unset → `False` | `True` | `DJANGO_SECURE_HSTS_INCLUDE_SUBDOMAINS` |
  | `SECURE_HSTS_PRELOAD` | unset → `False` | `False` (opt in) | `DJANGO_SECURE_HSTS_PRELOAD` |

  When `DEBUG=True` every knob automatically relaxes back to its old behaviour so plain-HTTP local development is unaffected.

- **`django_browser_reload`** is now mounted only when `DEBUG=True`. Previously the app, middleware, and `__reload__/` URL were registered unconditionally, so the dev-only helper was loaded in production. The conditional move applies in `settings.INSTALLED_APPS`, `settings.MIDDLEWARE`, and `PharmacyOnDuty/urls.py`.

### Why

Without these settings every production response was missing HSTS, cookies were transmittable over HTTP, and `manage.py check --deploy` flagged W004/W008/W012/W016 (and W006/W019 once `django_browser_reload` was excluded). The defaults follow Django's deployment checklist (https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/).

## Verification

```text
$ DJANGO_DEBUG=False DJANGO_SECRET_KEY=… python manage.py check --deploy
System check identified some issues:
WARNINGS:
?: (security.W009) Your SECRET_KEY has less than 50 characters … (test key only)
?: (security.W021) You have not set the SECURE_HSTS_PRELOAD setting to True. (opt-in)
System check identified 2 issues (0 silenced).
```

```text
$ DJANGO_DEBUG=True  DJANGO_SECRET_KEY=… python manage.py check
System check identified no issues (0 silenced).
$ DJANGO_DEBUG=False DJANGO_SECRET_KEY=… python manage.py check
System check identified no issues (0 silenced).
```

`pytest pharmacies/tests/test_utils.py test_input_validation.py test_istanbul_scraper.py test_eskisehir_scraper.py test_ankara_scraper.py test_sentry_config.py test_sitemaps.py` → 40 passed locally (DB-backed tests skipped because Postgres is unreachable in this environment). `ruff check` and `ruff format --check` are clean.

## Test plan

- [ ] CI passes the full pytest + ruff suite
- [ ] After deploy, confirm the response carries `Strict-Transport-Security`, `Set-Cookie: …; Secure`, and that HTTP requests redirect to HTTPS
- [ ] Verify `/__reload__/` returns 404 in production
- [ ] Operators can still opt-out via env vars if a particular environment terminates TLS upstream

🔒 Filed by security-audit agent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced security configuration with environment variable-driven settings for HTTPS redirect, HSTS headers, and secure cookies in production environments.
  * Improved reverse proxy support with configurable TLS detection.

* **Documentation**
  * Updated documentation for proxy SSL configuration requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->