### PR TITLE
🚀 ci: grant pull-requests write to Claude review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 
@@ -41,4 +41,3 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-


### PR DESCRIPTION
## Summary
- `anthropics/claude-code-action@v1` was running on every PR but silently failing to post inline review comments
- Root cause: workflow granted `pull-requests: read`, so the post-buffered-inline-comments step had no write access
- Run logs showed `permission_denials_count: 1` and `No buffered inline comments` while the job itself reported success

## Fix
- Bump `pull-requests` permission from `read` to `write` in `.github/workflows/claude-code-review.yml`

## Test plan
- [ ] This PR itself triggers Claude Code Review — verify inline review comments now appear on the diff
- [ ] Workflow run logs should show no `permission_denials_count` and a non-zero buffered inline comments count