### PR TITLE
🔒 security: bump pygments to 2.20.0 (CVE-2026-4539)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,4 +145,5 @@ dev = [
     "ty>=0.0.4",
     "interrogate>=1.7.0",
     "faker>=40.1.0",
+    "pygments>=2.20.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -726,6 +726,7 @@ dev = [
     { name = "interrogate" },
     { name = "mypy" },
     { name = "pre-commit" },
+    { name = "pygments" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-django" },
@@ -777,6 +778,7 @@ dev = [
     { name = "interrogate", specifier = ">=1.7.0" },
     { name = "mypy", specifier = ">=1.18.2" },
     { name = "pre-commit", specifier = ">=4.5.0" },
+    { name = "pygments", specifier = ">=2.20.0" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "pytest-django", specifier = ">=4.11.1" },
@@ -891,11 +893,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bumps `pygments` to **2.20.0** to resolve **CVE-2026-4539** (GHSA-5239-wwwm-4pmq): *Regular Expression Denial of Service (ReDoS) due to inefficient regex for GUID matching* in `AdlLexer` (`pygments/lexers/archetype.py`). Affects `2.19.0`–`2.19.2`; fixed in `2.20.0`. CVSS 4.8 (medium).

`pygments` is a **dev-only** transitive dependency via `pytest` (used to colourise pytest's terminal output). Real-world exploitability from this project is limited to developers running the test suite against pathological input, but the fix is trivial and keeps `pip-audit` clean.

### Change

```toml
# pyproject.toml → [dependency-groups].dev
+ "pygments>=2.20.0",
```

The resolver picks `pygments==2.20.0` until `pytest` itself bumps its lower bound. No runtime (`dependencies`) changes.

### Verification

```text
$ pip-audit --requirement <(uv export --no-hashes)
Resolved 88 packages in 7ms
Found 1 known vulnerability in 1 package        # py 1.11.0 / PYSEC-2022-42969
                                                 # (SVN-only codepath in interrogate;
                                                 #  disputed, no fix available)
```

Before the bump, `pygments 2.19.2 / CVE-2026-4539` also appeared in that list. After the bump, only the non-actionable `py` advisory remains (disputed, SVN-only, tracked separately if an upstream fix lands).

```text
$ uv sync           # ✓ Audited 87 packages
$ uv run ruff check .   # ✓ All checks passed!
```

`pytest` could not be run on the host (GDAL not installed outside the Docker dev stack, same as PR #92). The change is a one-line dev-dep floor with no logic impact; CI will run the full suite.

## References

- https://github.com/advisories/GHSA-5239-wwwm-4pmq
- https://www.cvedetails.com/cve/CVE-2026-4539/
- https://advisories.gitlab.com/pkg/pypi/pygments/CVE-2026-4539/

## Test plan

- [ ] CI passes the full pytest + ruff suite
- [ ] Confirm `pip-audit` in CI no longer reports `CVE-2026-4539`

🛡️ Filed by security-audit agent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration with additional development dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->