### PR TITLE
🚑️ ci: make Claude Code Review actually post comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -38,6 +38,8 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
+          claude_args: >-
+            --allowed-tools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(gh pr comment:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),mcp__github_inline_comment__create_inline_comment"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
## Summary

The `Claude Code Review` workflow has been silently broken since it was scaffolded — every run reports CI "success" but never posts a single inline comment. Two defects, both verified against the upstream `code-review` plugin source:

1. **Missing `--comment` flag.** The plugin's slash command (`anthropics/claude-code/plugins/code-review/commands/code-review.md`, step 7) literally says: *"If `--comment` argument was NOT provided, stop here. Do not post any GitHub comments."* Our prompt omitted it, so the plugin did the review and stopped by design.
2. **Missing tool permissions.** The plugin declares its required tools in frontmatter (`Bash(gh pr view:*)` … `mcp__github_inline_comment__create_inline_comment`), but `claude-code-action@v1` does not merge slash-command frontmatter into the SDK's permission policy. Every posting attempt hit the permission layer and got denied (`permission_denials_count: 5` in the latest run; `No buffered inline comments` in the post step).

Fix: append `--comment` to the prompt and pass the plugin's exact allowed-tools list through `claude_args`.

## Known caveat: this PR's own review run will fail

`claude-code-action@v1` refuses to run on a PR whose workflow file differs from `main`'s (self-validation trap — see PR #100). So the Claude review on this PR will fail with `Workflow validation failed` — **that's expected, ignore it**. The fix is only testable after merge, by triggering a `synchronize` event on a non-workflow PR (e.g. `gh pr update-branch 95`).

## Test plan

After merge:
- [ ] `gh pr update-branch 95` to retrigger the review on PR #95 with the fixed workflow
- [ ] `gh run view <new-run-id> --log | grep permission_denials_count` shows `0`
- [ ] `gh run view <new-run-id> --log | grep "buffered inline comments"` no longer shows `No buffered inline comments` (or the plugin genuinely finds nothing to flag and posts a summary comment via `gh pr comment` per step-7)
- [ ] `gh api repos/gidorah/PharmacyOnDuty/pulls/95/comments` or `.../issues/95/comments` shows at least one comment from `claude[bot]`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review workflow configuration to enhance review capabilities with commenting functionality and restricted tool permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->