### PR TITLE
fix(maps): restore route rendering and viewport auto-fit

### DIFF
--- a/pharmacies/tests/test_views.py
+++ b/pharmacies/tests/test_views.py
@@ -182,12 +182,10 @@ class TestOtherViews:
         assert response["Content-Type"] == "text/javascript"
 
         # The proxy must request the libraries needed by the modern Maps JS
-        # APIs: "marker" for AdvancedMarkerElement and "routes" for
-        # Route.computeRoutes. The Routes JS library currently lives in the
-        # "beta" release channel.
+        # APIs: "marker" for AdvancedMarkerElement, and "routes" for the
+        # modular DirectionsService / DirectionsRenderer imports.
         _, call_kwargs = mock_get.call_args
         params = call_kwargs["params"]
-        assert params["v"] == "beta"
         libraries = set(params["libraries"].split(","))
         assert {"marker", "routes", "geometry"} <= libraries
 

--- a/pharmacies/views.py
+++ b/pharmacies/views.py
@@ -124,12 +124,11 @@ def google_maps_proxy(request: HttpRequest) -> HttpResponse | JsonResponse:
 
     endpoint = "https://maps.googleapis.com/maps/api/js"
     # The "marker" library is required for AdvancedMarkerElement and the
-    # "routes" library is required for google.maps.routes.Route.computeRoutes
-    # (the supported replacement for the deprecated DirectionsService).
-    # The Routes JS library currently ships in the "beta" release channel.
+    # "routes" library provides DirectionsService / DirectionsRenderer via
+    # google.maps.importLibrary("routes"), which is the non-deprecated
+    # modular access pattern for those classes.
     params = {
         "key": settings.GOOGLE_MAPS_API_KEY,
-        "v": "beta",
         "libraries": "marker,routes,geometry",
         **dict(request.GET),
     }

--- a/theme/templates/pharmacies.html
+++ b/theme/templates/pharmacies.html
@@ -91,25 +91,29 @@
 		let map;
 		// Lazily-resolved constructors from the Maps JS modular libraries.
 		let AdvancedMarkerElementCtor;
-		let RouteCls;
+		let directionsService;
+		let directionsRenderer;
 		// Track whether the list is expanded or collapsed
 		let isExpanded = false;
 		let userLocation;
 		let markersArray = [];
-		let routePolylines = [];
 
 		async function initMap(center = { lat: 40.7128, lng: -74.0060 }) {
-			// Load the modular libraries we need. "marker" provides
-			// AdvancedMarkerElement (replaces the deprecated google.maps.Marker)
-			// and "routes" provides Route.computeRoutes (replaces the
-			// deprecated DirectionsService / DirectionsRenderer).
-			const [{ Map }, { AdvancedMarkerElement }, { Route }] = await Promise.all([
+			// Load the modular libraries via importLibrary so we don't rely on
+			// the deprecated global google.maps.* namespace access pattern.
+			// "marker" provides AdvancedMarkerElement (the replacement for the
+			// deprecated google.maps.Marker); "routes" provides
+			// DirectionsService / DirectionsRenderer.
+			const [
+				{ Map },
+				{ AdvancedMarkerElement },
+				{ DirectionsService, DirectionsRenderer },
+			] = await Promise.all([
 				google.maps.importLibrary("maps"),
 				google.maps.importLibrary("marker"),
 				google.maps.importLibrary("routes"),
 			]);
 			AdvancedMarkerElementCtor = AdvancedMarkerElement;
-			RouteCls = Route;
 
 			map = new Map(document.getElementById("map"), {
 				center: center,
@@ -124,6 +128,12 @@
 				streetViewControl: false,
 				rotateControl: false,
 				fullscreenControl: false,
+			});
+
+			directionsService = new DirectionsService();
+			directionsRenderer = new DirectionsRenderer({
+				suppressMarkers: true,
+				map: map,
 			});
 		}
 
@@ -277,41 +287,24 @@
 			});
 		}
 
-		function clearRoutePolylines() {
-			routePolylines.forEach((polyline) => polyline.setMap(null));
-			routePolylines = [];
-		}
-
 		async function showDirectionsToMarker(point, userLocation) {
-			if (!userLocation || !point || !RouteCls) {
+			if (!userLocation || !point || !directionsService || !directionsRenderer) {
 				return;
 			}
 			try {
-				const { routes } = await RouteCls.computeRoutes({
+				const result = await directionsService.route({
 					origin: { lat: userLocation.lat, lng: userLocation.lng },
 					destination: {
 						lat: point.position.lat,
 						lng: point.position.lng,
 					},
-					travelMode: "DRIVING",
-					// Field mask: only request the polyline path. createPolylines()
-					// requires the "path" field to be present in the response.
-					fields: ["path"],
+					travelMode: google.maps.TravelMode.DRIVING,
 				});
-
-				if (!routes || routes.length === 0) {
-					console.error("Routes API returned no routes.");
-					return;
-				}
-
-				clearRoutePolylines();
-				const polylines = routes[0].createPolylines();
-				polylines.forEach((polyline) => {
-					polyline.setMap(map);
-					routePolylines.push(polyline);
-				});
+				// DirectionsRenderer draws the polyline AND auto-fits the
+				// viewport to the route bounds by default.
+				directionsRenderer.setDirections(result);
 			} catch (err) {
-				console.error("Routes computeRoutes failed:", err);
+				console.error("Directions request failed:", err);
 			}
 		}
 


### PR DESCRIPTION
## Summary

Fixes two regressions introduced by #104:

1. **Route no longer drew on the map** — the `Route.computeRoutes({ fields: ["path"] })` + `createPolylines()` flow (Routes JS, `v=beta`) silently produced nothing that rendered.
2. **Map no longer zoomed to fit the route** — `DirectionsRenderer` auto-fits the viewport by default; raw `Polyline`s do not, and nothing in #104 replaced that behavior.

PR #104 misdiagnosed the deprecation warnings it was chasing. `google.maps.Marker` **is** deprecated (keep the `AdvancedMarkerElement` migration from #104), but `DirectionsService` / `DirectionsRenderer` are **not** deprecated — only the global-namespace access pattern (`new google.maps.DirectionsService()`) is. The fix re-imports both modularly via `google.maps.importLibrary("routes")`, which keeps the warnings silenced **and** restores the working directions flow in one shot.

## Changes

- `theme/templates/pharmacies.html`
  - `initMap()` now destructures `DirectionsService` and `DirectionsRenderer` from `importLibrary("routes")` alongside the existing marker imports and recreates the service + renderer (`suppressMarkers: true`) after the `new Map(...)` call.
  - `showDirectionsToMarker()` is back to `directionsService.route(...)` → `directionsRenderer.setDirections(result)`. `DirectionsRenderer` redraws the polyline **and** auto-fits the viewport.
  - Removed the unused `RouteCls`, `routePolylines`, and `clearRoutePolylines()` code.
  - `AdvancedMarkerElement` migration from #104 is preserved as-is.

- `pharmacies/views.py`
  - Dropped `"v": "beta"` from the Google Maps proxy params — `DirectionsService`/`DirectionsRenderer` ship in stable.
  - Rewrote the misleading comment that called `Route.computeRoutes` "the replacement for the deprecated DirectionsService".
  - Kept `libraries=marker,routes,geometry`.

- `pharmacies/tests/test_views.py`
  - Removed the `params["v"] == "beta"` assertion from `test_google_maps_proxy`.
  - Kept the `{"marker", "routes", "geometry"} <= libraries` assertion.

## Test plan

- [x] `uv run ruff check pharmacies/views.py pharmacies/tests/test_views.py` — clean
- [x] `uv run ruff format --check pharmacies/views.py pharmacies/tests/test_views.py` — already formatted
- [x] `uv run mypy pharmacies/views.py pharmacies/tests/test_views.py` — no issues
- [x] Pre-commit hooks (ruff, ruff-format, djLint, mypy, tailwind build) — all green
- [ ] `just test` — **needs to run in the dev stack**; local run was blocked by an unrelated host container holding port 5432.
- [ ] **Manual verification in a browser** (the step that was skipped on #104 and let these regressions ship):
  - Pharmacy and user-location pins render (AdvancedMarkerElement regression check).
  - Clicking "Yol Tarifi" draws a driving polyline between the user and the pharmacy.
  - Map viewport auto-zooms to fit the full route.
  - DevTools Console has **no** `google.maps.Marker` / `DirectionsService` / `DirectionsRenderer` deprecation warnings.
  - Network tab: `/google_maps_proxy?...` resolves to a Maps JS URL whose query contains `libraries=marker,routes,geometry` and **no `v=beta`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Google Maps API configuration for the pharmacy directions feature.
  * Refactored how directions are rendered on the map using an updated approach.

* **Tests**
  * Updated Google Maps proxy test assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->