### PR TITLE
🔒️ fix(xss): render pharmacy fields via DOM APIs on /

### DIFF
--- a/theme/templates/pharmacies.html
+++ b/theme/templates/pharmacies.html
@@ -168,9 +168,16 @@
 			markersArray.push(pharmacyMarker);
 
 			// Info Window for pharmacy marker. AdvancedMarkerElement uses
-			// the new {anchor, map} open() signature.
+			// the new {anchor, map} open() signature. Build the content as
+			// a DOM node so pharmacy fields are never parsed as HTML.
+			const infoContent = document.createElement("div");
+			const infoTitle = document.createElement("h3");
+			infoTitle.textContent = point.title ?? "";
+			const infoAddress = document.createElement("p");
+			infoAddress.textContent = point.address ?? "";
+			infoContent.append(infoTitle, infoAddress);
 			const infoWindow = new google.maps.InfoWindow({
-				content: `<h3>${point.title}</h3><p>${point.address || ""}</p>`,
+				content: infoContent,
 			});
 			pharmacyMarker.addListener("gmp-click", () => {
 				infoWindow.open({ anchor: pharmacyMarker, map: map });
@@ -192,34 +199,54 @@
 		}
 
 		function updatePharmacyList(pharmacies) {
-			const pharmacyItems = $('#pharmacy-items');
-			pharmacyItems.empty(); // Clear existing list
+			const pharmacyItems = document.getElementById("pharmacy-items");
+			pharmacyItems.replaceChildren();
 
 			pharmacies.forEach((pharmacy) => {
-				const itemHtml = `
-					<div class="pharmacy-item bg-primary-100 shadow-sm rounded p-4 flex flex-col md:flex-row items-start md:items-center justify-between" data-name="${pharmacy.title}">
-						<div class="md:flex-grow">
-						<p class="text-lg font-semibold mb-1">${pharmacy.title}</p>
-						<p class="text-sm text-gray-600">
-							${pharmacy.address} <br /> (${pharmacy.travel_distance} metre uzaklıkta)
-						</p>
-						</div>
-						<div class="mt-2 md:mt-0 flex items-center space-x-3">
-						<span class="inline-block text-sm font-medium px-6 py-2 rounded bg-secondary border-2 border-secondary text-white">
-							${pharmacy.status}
-						</span>
-						<button
-							onclick="showDirectionsToPharmacy(${JSON.stringify(pharmacy)
-						.replace(/"/g, '&quot;')})"
-							class="inline-block px-6 py-2 bg-primary-100 text-secondary
-								rounded border-2 border-secondary text-sm"
-							type="button">
-							Yol Tarifi
-						</button>
-						</div>
-					</div>
-					`;
-				pharmacyItems.append(itemHtml);
+				const item = document.createElement("div");
+				item.className =
+					"pharmacy-item bg-primary-100 shadow-sm rounded p-4 flex flex-col md:flex-row items-start md:items-center justify-between";
+				item.dataset.name = pharmacy.title ?? "";
+
+				const infoWrap = document.createElement("div");
+				infoWrap.className = "md:flex-grow";
+
+				const titleEl = document.createElement("p");
+				titleEl.className = "text-lg font-semibold mb-1";
+				titleEl.textContent = pharmacy.title ?? "";
+
+				const addressEl = document.createElement("p");
+				addressEl.className = "text-sm text-gray-600";
+				addressEl.append(
+					document.createTextNode(pharmacy.address ?? ""),
+					document.createElement("br"),
+					document.createTextNode(
+						` (${Number(pharmacy.travel_distance) || 0} metre uzaklıkta)`,
+					),
+				);
+
+				infoWrap.append(titleEl, addressEl);
+
+				const actionsWrap = document.createElement("div");
+				actionsWrap.className = "mt-2 md:mt-0 flex items-center space-x-3";
+
+				const statusEl = document.createElement("span");
+				statusEl.className =
+					"inline-block text-sm font-medium px-6 py-2 rounded bg-secondary border-2 border-secondary text-white";
+				statusEl.textContent = pharmacy.status ?? "";
+
+				const button = document.createElement("button");
+				button.type = "button";
+				button.className =
+					"inline-block px-6 py-2 bg-primary-100 text-secondary rounded border-2 border-secondary text-sm";
+				button.textContent = "Yol Tarifi";
+				button.addEventListener("click", () => {
+					showDirectionsToPharmacy(pharmacy);
+				});
+
+				actionsWrap.append(statusEl, button);
+				item.append(infoWrap, actionsWrap);
+				pharmacyItems.append(item);
 			});
 		}
 


### PR DESCRIPTION
## Summary

Fixes #102 — a client-side XSS sink in `theme/templates/pharmacies.html`. Pharmacy `title`, `address`, `status`, and `travel_distance` (originating from scraped upstream sources) were interpolated into raw HTML via jQuery `.append()` and `google.maps.InfoWindow.content`, and the `Yol Tarifi` button was wired up via an inline `onclick=` attribute with only partial `&quot;` escaping.

Any pharmacy record whose name/address/district contained HTML metacharacters (from a compromised chamber site or a malicious directory submission) would execute arbitrary JS against every visitor.

## Changes

- **InfoWindow** — build `content` as a DOM node (`createElement` + `textContent`) instead of an HTML template literal, so the Maps SDK never parses pharmacy fields as HTML.
- **`updatePharmacyList`** — construct each list item with `createElement` / `textContent` / `dataset`. No more HTML-string sinks for `title`, `address`, `status`, or `data-name`. `travel_distance` is coerced with `Number()`.
- **Click handler** — the inline `onclick="showDirectionsToPharmacy(${JSON.stringify(pharmacy).replace(/"/g, '&quot;')})"` is replaced with a closure-based `button.addEventListener("click", ...)`. This drops the JSON-in-attribute round-trip entirely and removes the last inline event handler in the template — which also unblocks CSP hardening if we add it later.

## Scope / non-goals

This PR addresses remediation steps **1** and **2** from the issue. Defence-in-depth items (strict CSP; server-side `bleach.clean` during scraper ingest) are intentionally left for follow-ups so this PR stays focused and easy to review.

## Test plan

- [ ] `just dev-up` and load `/` — pharmacy list renders, titles/addresses/status are visible
- [ ] Click a pharmacy marker — InfoWindow shows title + address as plain text
- [ ] Click a `Yol Tarifi` button — directions render and the selected pharmacy name updates
- [ ] With a local DB row containing `<img src=x onerror=alert(1)>Test` in `name`, confirm the string renders literally (no alert) in both the InfoWindow and the list item