### PR TITLE
🔒 fix(security): restrict google_maps_proxy to allowlisted query params

### DIFF
--- a/pharmacies/views.py
+++ b/pharmacies/views.py
@@ -108,6 +108,11 @@ def is_allowed_referer(request: HttpRequest) -> bool:
     return any(referer.startswith(allowed) for allowed in settings.ALLOWED_REFERERS)
 
 
+_ALLOWED_PROXY_PARAMS: frozenset[str] = frozenset(
+    {"v", "language", "region", "callback", "loading"}
+)
+
+
 @cache_page(60 * 60)  # cache for 1 hour
 def google_maps_proxy(request: HttpRequest) -> HttpResponse | JsonResponse:
     """
@@ -123,14 +128,18 @@ def google_maps_proxy(request: HttpRequest) -> HttpResponse | JsonResponse:
         return HttpResponse("Forbidden", status=403)
 
     endpoint = "https://maps.googleapis.com/maps/api/js"
+    # Only forward explicitly allowed query parameters to prevent parameter
+    # pollution. Server-controlled keys are set last so they cannot be
+    # overridden by caller-supplied values (closes #93).
     # The "marker" library is required for AdvancedMarkerElement and the
     # "routes" library provides DirectionsService / DirectionsRenderer via
     # google.maps.importLibrary("routes"), which is the non-deprecated
     # modular access pattern for those classes.
-    params = {
+    user_params = {k: v for k, v in request.GET.items() if k in _ALLOWED_PROXY_PARAMS}
+    params: dict[str, object] = {
+        **user_params,
         "key": settings.GOOGLE_MAPS_API_KEY,
         "libraries": "marker,routes,geometry",
-        **dict(request.GET),
     }
 
     try:


### PR DESCRIPTION
Closes #93

## Vulnerability

`google_maps_proxy` merged the entire `request.GET` dict into the upstream Google Maps params using `**dict(request.GET)`. Because that spread came **after** the server defaults in the dict literal, a caller could supply `?key=attacker-key` or `?libraries=places,drawing` to **override** the server-controlled API key and library set.

```python
# Before — attacker can override key and libraries:
params = {
    "key": settings.GOOGLE_MAPS_API_KEY,
    "libraries": "marker,routes,geometry",
    **dict(request.GET),  # wins over the keys above
}
```

## Fix

Added an explicit allowlist (`v`, `language`, `region`, `callback`, `loading`) matching only the query params the frontend legitimately passes. Server-controlled params are placed **last** so they can never be clobbered.

```python
_ALLOWED_PROXY_PARAMS = frozenset({"v", "language", "region", "callback", "loading"})

user_params = {k: v for k, v in request.GET.items() if k in _ALLOWED_PROXY_PARAMS}
params = {
    **user_params,
    "key": settings.GOOGLE_MAPS_API_KEY,   # always wins
    "libraries": "marker,routes,geometry",  # always wins
}
```

## Checks

- `uv run ruff check --fix .` — ✅ all checks passed
- `uv run ruff format .` — ✅ no changes needed
- `uv run mypy .` / `uv run pytest -x` — ❌ pre-existing failure on host (missing GDAL system library, same error on unmodified `main`). CLAUDE.md documents that these must run inside the Docker stack; CI will confirm.

Auto-resolved by the Security Audit scheduled agent.