### PR TITLE
🐛 fix: pass CELERY_BROKER_URL to workers so Redis readiness check fires on startup (Sentry ECZANEREDE-J)

### DIFF
--- a/docker/prod/workers/docker-compose.yml
+++ b/docker/prod/workers/docker-compose.yml
@@ -7,3 +7,8 @@ services:
     command: uv run --no-dev celery -A PharmacyOnDuty worker -l info --hostname=scraper@%%h
     environment:
       - DJANGO_SETTINGS_MODULE=PharmacyOnDuty.settings
+      - CELERY_BROKER_URL=${CELERY_BROKER_URL}
+      - DB_HOST=${DB_HOST}
+      - DB_NAME=${DB_NAME}
+      - DB_USER=${DB_USER}
+      - DB_PASSWORD=${DB_PASSWORD}

--- a/pharmacies/tests/test_input_validation.py
+++ b/pharmacies/tests/test_input_validation.py
@@ -36,9 +36,9 @@ def test_invalid_coordinates(
     with patch("pharmacies.views.get_nearest_pharmacies_open", return_value=[]):
         response = get_pharmacy_points(request)
 
-    assert (
-        response.status_code == 400
-    ), f"Expected 400 for invalid lat, got {response.status_code}"
+    assert response.status_code == 400, (
+        f"Expected 400 for invalid lat, got {response.status_code}"
+    )
     # The error message content checking is what we want to verify
     assert b"Invalid coordinates" in response.content
 

--- a/tests/test_location_coverage.py
+++ b/tests/test_location_coverage.py
@@ -70,46 +70,46 @@ class TestLocationCoverage:
             )
             duration = (time.time() - start_time) * 1000
 
-            assert (
-                duration < 500
-            ), f"Slow response for {scenario['description']}: {duration:.2f}ms"
+            assert duration < 500, (
+                f"Slow response for {scenario['description']}: {duration:.2f}ms"
+            )
 
             if scenario["expected_behavior"] == "should_return_pharmacy":
-                assert (
-                    response.status_code == 200
-                ), f"Failed for {scenario['description']} (Expected 200, got {response.status_code})"
+                assert response.status_code == 200, (
+                    f"Failed for {scenario['description']} (Expected 200, got {response.status_code})"
+                )
                 data = response.json()
-                assert (
-                    "points" in data
-                ), f"No points returned for {scenario['description']}"
+                assert "points" in data, (
+                    f"No points returned for {scenario['description']}"
+                )
                 points = data["points"]
-                assert (
-                    len(points) > 0
-                ), f"Empty points list for {scenario['description']}"
+                assert len(points) > 0, (
+                    f"Empty points list for {scenario['description']}"
+                )
 
                 prev_distance = -1
                 for point in points:
-                    assert (
-                        "travel_distance" in point
-                    ), f"Missing travel_distance in {point}"
-                    assert (
-                        "travel_duration" in point
-                    ), f"Missing travel_duration in {point}"
+                    assert "travel_distance" in point, (
+                        f"Missing travel_distance in {point}"
+                    )
+                    assert "travel_duration" in point, (
+                        f"Missing travel_duration in {point}"
+                    )
 
                     curr_distance = point["travel_distance"]
-                    assert (
-                        curr_distance >= prev_distance
-                    ), f"Points not sorted by distance for {scenario['description']}"
+                    assert curr_distance >= prev_distance, (
+                        f"Points not sorted by distance for {scenario['description']}"
+                    )
                     prev_distance = curr_distance
             else:
                 # For scenarios not marked as 'should_return_pharmacy', we expect a 400 Bad Request
                 # because get_city_name_from_location will raise ValueError for unknown/out-of-scope locations,
                 # or City.DoesNotExist will be raised.
-                assert (
-                    response.status_code == 400
-                ), f"Expected 400 for {scenario['description']} but got {response.status_code}"
+                assert response.status_code == 400, (
+                    f"Expected 400 for {scenario['description']} but got {response.status_code}"
+                )
 
                 data = response.json()
-                assert (
-                    "error" in data
-                ), f"Missing error message for {scenario['description']}"
+                assert "error" in data, (
+                    f"Missing error message for {scenario['description']}"
+                )


### PR DESCRIPTION
## Summary

Closes #116 (and by extension #117, which is a cascading symptom of the same root cause).

**Sentry issues**: [ECZANEREDE-J](https://onur-akyuz.sentry.io/issues/ECZANEREDE-J) · [ECZANEREDE-P](https://onur-akyuz.sentry.io/issues/ECZANEREDE-P) · [ECZANEREDE-Q](https://onur-akyuz.sentry.io/issues/ECZANEREDE-Q)

---

## Root Cause

`docker/prod/workers/docker-compose.yml` was missing `CELERY_BROKER_URL` in the `worker` service environment. The prod Dockerfile sets `entrypoint.sh` which calls `wait_for_services.py` before starting Celery — but `wait_for_services.py` has this early-exit guard:

```python
broker_url = os.environ.get("CELERY_BROKER_URL")
if not broker_url:
    print("CELERY_BROKER_URL not set, skipping Redis wait.")
    return True   # ← no-op: Redis never checked
```

Without the env var, the Redis readiness gate is silently skipped and Celery starts immediately, hitting the "Connection refused" error during the brief window when Redis isn't yet up at deploy time. After 100 retries Celery raises `WorkerShutdown`, which cascades into `InterfaceError: connection already closed` as the `django_celery_results` backend tries to persist the failure to an already-torn-down DB connection (ECZANEREDE-P/Q).

## Fix

Added the missing environment variable pass-throughs to `docker/prod/workers/docker-compose.yml`:

```yaml
environment:
  - DJANGO_SETTINGS_MODULE=PharmacyOnDuty.settings
  - CELERY_BROKER_URL=${CELERY_BROKER_URL}   # ← NEW: enables Redis readiness gate
  - DB_HOST=${DB_HOST}                        # ← NEW: enables Postgres readiness gate
  - DB_NAME=${DB_NAME}
  - DB_USER=${DB_USER}
  - DB_PASSWORD=${DB_PASSWORD}
```

Values are forwarded from the Coolify deployment environment (consistent with how `beat`/`flower` are wired in `docker/prod/services/docker-compose.yml`).

## Checks

- `ruff check --fix .` — ✅ all checks passed
- `ruff format .` — ✅ (also reformatted two test files with cosmetic assert-style changes)
- `mypy` / `pytest` — require GDAL + running PostGIS container; confirmed the pre-existing failure on `main` is identical (host lacks GDAL library) and is unrelated to this YAML-only change

Auto-resolved by the Sentry scheduled agent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated worker service configuration with environment variables for broker and database connectivity.

* **Tests**
  * Refactored test assertions in validation and location coverage tests for improved code clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->