### PR TITLE
Skip Claude code review for dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,12 +12,7 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
Updated the Claude code review workflow to skip execution for automated dependabot pull requests, reducing unnecessary review overhead for dependency updates.

## Key Changes
- Replaced commented-out author filtering logic with a simple condition that excludes the `dependabot[bot]` actor
- This prevents the code review workflow from running on automated dependency update PRs while allowing it to run for all other contributors

## Implementation Details
The new condition `if: github.actor != 'dependabot[bot]'` is more maintainable than the previous commented approach and directly addresses the common use case of skipping reviews for bot-generated PRs. This is a best practice for CI/CD workflows to avoid redundant reviews of automated dependency updates.

https://claude.ai/code/session_014t4yV5gr9rYB6rmmCmVYqP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**No user-facing changes.** This release includes internal CI/CD automation updates to improve workflow efficiency and reliability.

* **Chores**
  * Updated code review automation workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->