### PR TITLE
🚀 ci: allow Claude Code Review to run on Dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'dependabot'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'


### PR DESCRIPTION
## Summary

Dependabot PRs have been failing the Claude Code Review workflow with:

> Action failed with error: Workflow initiated by non-human actor: dependabot (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.

`anthropics/claude-code-action@v1` blocks non-human actors by default and exposes `allowed_bots` as the idiomatic escape hatch. This PR sets `allowed_bots: 'dependabot'` so the plugin's bug-hunter agents can actually scan dependency bumps for subtle breakage.

Supersedes #119, which took the opposite approach (skip Dependabot entirely).

## Known caveat

This PR's own Claude review run will fail with `Workflow validation failed` (the action refuses to run on a PR whose workflow file differs from `main`'s). That's expected — the fix only becomes testable after merge.

## Test plan

After merge:
- [ ] `gh pr update-branch 106` (or any open Dependabot PR) to retrigger the review
- [ ] The new run should reach the plugin instead of failing at the actor gate
- [ ] `gh run view <id> --log | grep "Actor type"` → Bot, followed by normal plugin execution
- [ ] `gh api repos/gidorah/PharmacyOnDuty/issues/106/comments --jq '.[] | select(.user.login=="claude[bot]")'` → at least one summary comment