### PR TITLE
🚀 ci: skip Dependabot PRs in Claude Code Review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,12 +12,11 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
+    # Skip Dependabot-authored PRs: the action can't access OAuth secrets
+    # on Dependabot-triggered runs (GitHub secret scoping), so we'd need to
+    # provision a separate Dependabot secret to review them. Not worth it
+    # for dep bumps — use @claude on the PR if a manual review is wanted.
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -36,7 +35,6 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_bots: 'dependabot'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'


### PR DESCRIPTION
## Summary

Dependabot-triggered workflow runs don't get access to GitHub Actions secrets (GitHub security policy — secrets are withheld from bot-initiated \`pull_request\` events). The Claude review action needs \`secrets.CLAUDE_CODE_OAUTH_TOKEN\`, which resolves to an empty string on those runs, so it fails with:

> Environment variable validation failed: Either ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is required

Supplying a Dependabot-scoped copy of the token would work but requires minting a new OAuth token and adding it to the Dependabot secrets store — not worth it for dep bumps.

Instead: skip the job entirely for Dependabot PRs via a job-level \`if:\` condition. The run shows as a clean skip in the Actions UI instead of a failure. Reverts today's \`allowed_bots: 'dependabot'\` addition since it's now moot.

Manual override: if a specific Dependabot PR needs a Claude review, \`@claude\` the PR and the other workflow (\`claude.yml\`) will handle it.

## Known caveat

This PR's own Claude review run will fail with \`Workflow validation failed\` (the action refuses to run on a PR whose workflow file differs from \`main\`'s). Expected — ignore.

## Test plan

After merge:
- [ ] Trigger a fresh run on a Dependabot PR (\`@dependabot rebase\` on PR #108 or similar)
- [ ] Confirm the workflow run shows \`skipped\` (not \`failure\`) for the \`claude-review\` job
- [ ] Confirm a human-triggered run on a non-Dependabot PR still executes the review normally