### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix API key leakage in Google Maps proxy error message

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Empty string default in `os.environ.get("ALLOWED_REFERERS", " ").split(" ")` resulted in an empty string in the allowed referers list. Any string `.startswith("")` evaluates to True, causing the `is_allowed_referer` check to pass unconditionally.
 **Learning:** Defaulting to a single space `" "` and splitting by `" "` yields `['', '']`. Empty strings in security allow-lists that use `startswith()` checks or exact matches are extremely dangerous and can completely nullify the security controls.
 **Prevention:** Always filter out empty strings after splitting environment variable strings, e.g., `[x for x in env.split(" ") if x]`.
+
+## 2026-03-22 - [API Key Leak in Exception Message]
+**Vulnerability:** The Google Maps proxy endpoint caught `requests.exceptions.RequestException` and returned `str(e)` in its JSON response. Because the original request `params` included the Google Maps API key, the exception string contained the full requested URL, exposing the API key to the client.
+**Learning:** Returning raw exception strings from HTTP clients (`requests`, `httpx`, etc.) to end users is extremely dangerous, as these strings often embed full URLs, request headers, or payloads that contain sensitive credentials.
+**Prevention:** Always log HTTP client exceptions server-side (e.g., using `logging.error`) and return a generic, sanitized error message to the client.

--- a/pharmacies/tests/test_views.py
+++ b/pharmacies/tests/test_views.py
@@ -236,3 +236,18 @@ class TestProxyAwareCsrf:
 
         assert response.status_code == 200
         assert response.json()["points"][0]["title"] == "Open Pharmacy"
+
+    @patch("pharmacies.views.requests.get")
+    def test_google_maps_proxy_exception(
+        self, mock_get: MagicMock, client: Client
+    ) -> None:
+        import requests
+
+        mock_get.side_effect = requests.exceptions.RequestException("Connection error")
+
+        url = reverse("pharmacies:google_maps_proxy")
+        with patch("pharmacies.views.is_allowed_referer", return_value=True):
+            response = client.get(url)
+
+        assert response.status_code == 500
+        assert response.json() == {"error": "Failed to connect to the Maps service."}

--- a/pharmacies/views.py
+++ b/pharmacies/views.py
@@ -7,6 +7,7 @@ This module handles the HTTP requests for pharmacy data, including:
 - Proxying requests to the Google Maps API.
 """
 
+import logging
 from datetime import timedelta
 from json import JSONDecodeError, loads
 
@@ -137,7 +138,10 @@ def google_maps_proxy(request: HttpRequest) -> HttpResponse | JsonResponse:
         response = requests.get(endpoint, params=params, timeout=10)
         return HttpResponse(response.text, content_type="text/javascript")
     except requests.exceptions.RequestException as e:
-        return JsonResponse({"error": str(e)}, status=500)
+        logging.error("Google Maps API proxy error: %s", e)
+        return JsonResponse(
+            {"error": "Failed to connect to the Maps service."}, status=500
+        )
 
 
 def pharmacies_list(request: HttpRequest) -> HttpResponse:


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The Google Maps proxy caught `requests.exceptions.RequestException` and returned `str(e)` in the JSON response. Since the `requests` exception message often includes the full requested URL, and the URL included the API key in the `params`, this exposed the server's Google Maps API key to any client that could trigger an upstream network error.
🎯 Impact: An attacker could intentionally cause the upstream request to fail (e.g., by sending an invalid parameter) to extract the API key from the error message. This key could then be abused, potentially leading to significant financial costs.
🔧 Fix: Replaced `str(e)` with a generic "Failed to connect to the Maps service." message in the client response. The actual exception is now securely logged server-side via `logging.error`.
✅ Verification: Ran the test suite. Added `test_google_maps_proxy_exception` to confirm that the endpoint now returns the sanitized error message and a 500 status code when an exception occurs.

---
*PR created automatically by Jules for task [1852573802834928853](https://jules.google.com/task/1852573802834928853) started by @gidorah*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a security issue where error messages from the Google Maps proxy endpoint could expose sensitive API key information. Error responses now return a generic message instead of raw exception details.

* **Tests**
  * Added test coverage for exception handling in the Google Maps proxy endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->