### PR TITLE
🐛 fix: per-district exception handling in Istanbul scraper (Sentry ECZANEREDE-M)

### DIFF
--- a/pharmacies/tests/test_istanbul_scraper.py
+++ b/pharmacies/tests/test_istanbul_scraper.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
@@ -63,21 +64,26 @@ def test_get_istanbul_data(mock_post: MagicMock) -> None:
 
 @patch("pharmacies.utils.istanbul_saglik_scraper.requests.post")
 @patch("pharmacies.utils.istanbul_saglik_scraper.DISTRICTS", ["Adalar"])
-def test_get_istanbul_data_failure(mock_post: MagicMock) -> None:
+def test_get_istanbul_data_failure(
+    mock_post: MagicMock, caplog: pytest.LogCaptureFixture
+) -> None:
     mock_response = MagicMock()
     mock_response.raise_for_status.side_effect = HTTPError("500")
     mock_post.return_value = mock_response
 
-    with pytest.raises(HTTPError):
-        get_istanbul_data()
+    with caplog.at_level(
+        logging.WARNING, logger="pharmacies.utils.istanbul_saglik_scraper"
+    ):
+        data = get_istanbul_data()
 
-    mock_response.raise_for_status.assert_called_once()
+    assert data == []
+    assert any("Adalar" in r.message for r in caplog.records)
 
 
 @patch("pharmacies.utils.istanbul_saglik_scraper.requests.post")
 @patch("pharmacies.utils.istanbul_saglik_scraper.DISTRICTS", ["Adalar", "Ataşehir"])
-def test_get_istanbul_data_raises_on_connection_error_after_partial_fetch(
-    mock_post: MagicMock,
+def test_get_istanbul_data_skips_district_on_connection_error(
+    mock_post: MagicMock, caplog: pytest.LogCaptureFixture
 ) -> None:
     html_content = """
     <div class="card">
@@ -94,15 +100,22 @@ def test_get_istanbul_data_raises_on_connection_error_after_partial_fetch(
     mock_response.text = html_content
     mock_post.side_effect = [mock_response, ConnectionError("down")]
 
-    with pytest.raises(ConnectionError):
-        get_istanbul_data()
+    with caplog.at_level(
+        logging.WARNING, logger="pharmacies.utils.istanbul_saglik_scraper"
+    ):
+        data = get_istanbul_data()
 
+    assert len(data) == 1
+    assert data[0]["district"] == "Adalar"
     assert mock_post.call_count == 2
+    assert any("Ataşehir" in r.message for r in caplog.records)
 
 
 @patch("pharmacies.utils.istanbul_saglik_scraper.requests.post")
 @patch("pharmacies.utils.istanbul_saglik_scraper.DISTRICTS", ["Adalar"])
-def test_get_istanbul_data_missing_tags(mock_post: MagicMock) -> None:
+def test_get_istanbul_data_missing_tags(
+    mock_post: MagicMock, caplog: pytest.LogCaptureFixture
+) -> None:
     # Structure where tags are missing or malformed to hit else branches
     html_content = """
     <div class="card">
@@ -126,11 +139,13 @@ def test_get_istanbul_data_missing_tags(mock_post: MagicMock) -> None:
     mock_response.text = html_content
     mock_post.return_value = mock_response
 
-    # Capture print output to verify warning
-    with patch("builtins.print") as mock_print:
+    with caplog.at_level(
+        logging.WARNING, logger="pharmacies.utils.istanbul_saglik_scraper"
+    ):
         data = get_istanbul_data()
-        assert len(data) == 0
-        mock_print.assert_called_with("Warning: Unable to get coordinates for N/A")
+
+    assert len(data) == 0
+    assert any("Unable to get coordinates" in r.message for r in caplog.records)
 
 
 @patch("pharmacies.utils.istanbul_saglik_scraper.requests.post")

--- a/pharmacies/utils/istanbul_saglik_scraper.py
+++ b/pharmacies/utils/istanbul_saglik_scraper.py
@@ -190,7 +190,11 @@ def get_istanbul_data() -> list[dict[str, Any]]:
 
             coordinates = _get_coordinates_from_sehirharitasi_url(directions_url)
             if coordinates is None:
-                logger.warning("Unable to get coordinates for %s", pharmacy["name"])
+                logger.warning(
+                    "Unable to get coordinates for pharmacy %s in district %s",
+                    pharmacy["name"],
+                    district_name,
+                )
                 continue
 
             pharmacy["coordinates"] = coordinates

--- a/pharmacies/utils/istanbul_saglik_scraper.py
+++ b/pharmacies/utils/istanbul_saglik_scraper.py
@@ -5,6 +5,7 @@ Fetches duty pharmacy data for all districts in Istanbul.
 """
 
 import csv
+import logging
 from datetime import datetime, timedelta
 from typing import Any
 from urllib.parse import parse_qs, urlparse
@@ -13,6 +14,8 @@ import requests
 from bs4 import BeautifulSoup
 from bs4.element import Tag
 from django.utils import timezone
+
+logger = logging.getLogger(__name__)
 
 BASE_URL = "https://nobetcieczane.istanbulsaglik.gov.tr:88/"
 API_ENDPOINT = f"{BASE_URL}Home/GetEczaneler"
@@ -124,8 +127,16 @@ def get_istanbul_data() -> list[dict[str, Any]]:
 
     for district_name in DISTRICTS:
         payload = {"ilce": district_name}
-        response = requests.post(API_ENDPOINT, params=payload, timeout=10)
-        response.raise_for_status()
+        try:
+            response = requests.post(API_ENDPOINT, params=payload, timeout=10)
+            response.raise_for_status()
+        except requests.exceptions.RequestException as e:
+            logger.warning(
+                "Failed to fetch Istanbul pharmacies for district %s: %s",
+                district_name,
+                e,
+            )
+            continue
 
         html_content = response.text
         soup = BeautifulSoup(html_content, "html.parser")
@@ -179,7 +190,7 @@ def get_istanbul_data() -> list[dict[str, Any]]:
 
             coordinates = _get_coordinates_from_sehirharitasi_url(directions_url)
             if coordinates is None:
-                print(f"Warning: Unable to get coordinates for {pharmacy['name']}")
+                logger.warning("Unable to get coordinates for %s", pharmacy["name"])
                 continue
 
             pharmacy["coordinates"] = coordinates


### PR DESCRIPTION
Closes #134

## Root cause

`get_istanbul_data()` in `pharmacies/utils/istanbul_saglik_scraper.py` iterated over all 39 Istanbul districts with no per-request error handling. When `nobetcieczane.istanbulsaglik.gov.tr:88` was unreachable (`[Errno 113] No route to host`), the very first district (`Adalar`) raised `ConnectionError` and aborted the entire loop — all 39 districts skipped in a single task failure. This generated 419 Sentry events over 9 days (ECZANEREDE-M).

## Fix

Wrapped each district's `requests.post()` + `response.raise_for_status()` in `try/except requests.exceptions.RequestException`. On failure the district is skipped with a `logger.warning` and the loop continues to the next district. Also converted a bare `print()` at the coordinates-missing guard to `logger.warning()` for consistent observability.

**Before:** one unreachable district → entire scrape aborted → 419 Celery task failures
**After:** one unreachable district → warning logged, district skipped → remaining 38 districts still scraped

## Checks

- `uv run ruff check --fix .` — ✅ all checks passed
- `uv run ruff format .` — ✅ 1 file unchanged
- `uv run mypy .` / `uv run pytest -x` — ❌ pre-existing host failure (GDAL system library missing on this host — same error on unmodified `main`, documented in PRs #114, #123, #126). CI runs inside the Docker stack where GDAL is present.

Auto-resolved by the Sentry scheduled agent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNJQG4Y9DLsdtJQUoSHfwP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for network issues, allowing the scraper to continue processing when individual districts encounter failures instead of stopping completely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->