### PR TITLE
🔒 fix(security): move SecurityMiddleware before WhitenoiseMiddleware

### DIFF
--- a/PharmacyOnDuty/settings.py
+++ b/PharmacyOnDuty/settings.py
@@ -115,8 +115,8 @@ TAILWIND_APP_NAME = "theme"
 
 
 MIDDLEWARE = [
-    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",


### PR DESCRIPTION
Closes #113

## Vulnerability

`PharmacyOnDuty/settings.py` listed `WhitenoiseMiddleware` at position 0 and `SecurityMiddleware` at position 1. WhiteNoise short-circuits the Django middleware chain for static-file requests, responding before `SecurityMiddleware` runs. This means security headers added by `SecurityMiddleware` — `X-Content-Type-Options: nosniff`, `Strict-Transport-Security`, and `X-Frame-Options` — were **absent from all static-file responses** (CSS, JS, images).

## Fix

Swapped the two entries so `SecurityMiddleware` is first. It now wraps every response — including those returned by WhiteNoise — ensuring security headers are present on all HTTP responses.

```diff
 MIDDLEWARE = [
-    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
```

This is the approach recommended by Django's deployment checklist and the WhiteNoise documentation. No functional behaviour changes — WhiteNoise still serves static files efficiently; it just does so with security headers now present.

## Checks

- `uv run ruff check --fix .` — ✅ all checks passed
- `uv run ruff format .` — ✅ 48 files unchanged
- `uv run mypy .` / `uv run pytest -x` — ❌ pre-existing host failure (GDAL system library missing on this host — same error on unmodified `main`, documented in PRs #114, #123, #126). CI runs inside the Docker stack where GDAL is present.

Auto-resolved by the Security Audit scheduled agent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VCEv5vW1q5YjyXSi6Afp6w)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized request processing through middleware configuration adjustment to improve application security and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->