### PR TITLE
Update Coolify defaults to keep admin ports local

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,81 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Project
+
+Pharmacy on-duty finder for Turkey (Eskişehir, Istanbul, Ankara). Django 5 + GeoDjango/PostGIS, Celery/Redis, Tailwind. Python 3.13, `uv` for deps, `just` as task runner, Docker Compose for environments.
+
+## Commands
+
+Everything routes through `just`, which shells into the dev Docker Compose stack. Do not invoke `python`/`pytest`/`pip` on the host — use `uv run` inside the container (or via `just`).
+
+```bash
+just dev-up          # Start dev stack (django, db, redis, celery, beat, flower)
+just dev-rebuild     # Rebuild + start
+just dev-down
+just dev-django      # Shell into the django container
+just dev-db          # psql into the PostGIS db
+just logs <service>  # Tail one service
+
+just migrate / just makemigrations
+just shell           # Django shell
+just seed            # Run seed_cities management command
+just test            # Runs `manage.py test` inside container
+
+# Single test via pytest (preferred for dev):
+just manage "test pharmacies.tests.test_views.TestNearest::test_happy_path"
+# or inside `just dev-django`:
+uv run pytest pharmacies/tests/test_views.py::TestNearest::test_happy_path -x
+```
+
+Lint/format/type-check (run inside container or via `uv run`):
+```bash
+uv run ruff check --fix .
+uv run ruff format .
+uv run mypy .
+```
+
+Pytest is configured via `pyproject.toml` with `DJANGO_SETTINGS_MODULE=PharmacyOnDuty.settings` and `--cov=pharmacies`. Test discovery covers both `tests/` (top-level infra/perf tests) and `pharmacies/tests/` (domain tests).
+
+## Architecture
+
+**Django project**: `PharmacyOnDuty/` holds settings, urls, celery app, sitemaps, and `database_config.py` (env-driven DB selection).
+
+**Core domain**: `pharmacies/` is the only app.
+- `models.py` — `City`, `Pharmacy` (PostGIS Point), `ScraperConfig`, `WorkingSchedule`. `ScraperConfig.save()` mutates `django-celery-beat` `PeriodicTask` rows, so scraping cadence is controlled from the DB, not code.
+- `utils/` — one `*_scraper.py` per city chamber (`ankaraeo`, `eskisehireo`, `istanbul_saglik`) plus shared helpers in `utils.py`. Scrapers must return the standardized dict (`name`, `address`, `district`, `phone`, `coordinates.{lat,lng}`, `duty_start`, `duty_end`) and are registered in `utils/utils.py:get_city_data` — do not wire them up anywhere else.
+- `tasks.py` — Celery entrypoints that invoke scrapers; results ingested via `utils.py:add_scraped_data_to_db` (bulk UPSERT with a pre-fetched lookup map; **never** loop `.save()`).
+- `views.py` — geo-spatial endpoints. Nearest-pharmacy search uses `Distance` annotations via `utils.py:get_nearest_pharmacies_on_duty`; travel time uses Google Distance Matrix separately.
+- `management/commands/seed_cities.py` — bootstraps City rows.
+
+**GIS gotcha**: GeoDjango `Point(x, y)` expects `(lng, lat)`, not `(lat, lng)`. Always validate scraped coordinates before constructing a Point. Use `utils.py:normalize_string` for Turkish character handling.
+
+**Frontend**: `theme/` is a `django-tailwind` app. Build CSS with `uv run python manage.py tailwind build` (or the dev watcher). Don't hand-write raw CSS — use Tailwind classes.
+
+**Docker layout** (`docker/`):
+- `dev/` — hot-reload stack, mounts host source, runs as UID 1000 (`python` user), isolated venv at `/opt/venv` (never mount host `.venv`).
+- `prod/services/` — web stack (gunicorn + nginx + redis + db).
+- `prod/workers/` — scalable Celery worker stack.
+- `postgis/` — custom PostGIS image with auto-init.
+- Containers run `uv sync` on startup; entrypoint scripts live in `/usr/local/bin/` so they aren't masked by volume mounts. `scripts/wait_for_services.py` gates startup on DB/Redis.
+
+**Observability**: Sentry auto-initializes if `SENTRY_DSN` is set. Flower is exposed at `localhost:5555` in dev. `debugpy` auto-attaches if its port env var is set.
+
+**Deployment**: Coolify/PaaS via `Procfile` + `Aptfile` (GDAL/Proj system deps) + `scripts/on_deploy.sh`.
+
+## Conventions & gates
+
+- **`uv` only.** No `pip`, no manual venvs. `uv sync` / `uv run` / `uv add`.
+- **Strict mypy** (`python_version = 3.13`, `strict = true`) — don't weaken it; fix types properly.
+- **Ruff** is the sole linter/formatter (`E4/E7/F/I/UP`, line length 88, double quotes). Never suppress a lint error to make it go away — if you can't resolve it, ask.
+- **Commits**: use the `committing-changes` skill. Direct `git commit` is prohibited by global policy.
+- **Bulk DB ops**: `bulk_create(ignore_conflicts=True)` / `bulk_update`. Ingest performance is enforced by tests in `pharmacies/tests/test_scraper_performance.py`.
+- **Time**: `timezone.now()`, never `datetime.now()`.
+- **Scraper tests** mock `requests.get`; don't hit the network.
+
+## Companion docs
+
+- `AGENTS.md` (root) and `pharmacies/AGENTS.md`, `docker/AGENTS.md` — per-area knowledge bases; read the relevant one before non-trivial edits in that area.
+- `GEMINI.md` — mostly overlaps with this file; kept for the Gemini review workflows in `.github/`.
+- `readme.md` — long-form product/feature doc.

--- a/docker/prod/services/docker-compose.yml
+++ b/docker/prod/services/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       dockerfile: docker/prod/Dockerfile
     restart: always
     ports:
-      - "${DJANGO_HOST_PORT:-0}:8000"
+      - "${DJANGO_HOST_PORT:-127.0.0.1:8000}:8000"
     depends_on:
       - db
     environment:
@@ -37,7 +37,7 @@ services:
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       POSTGRES_DB: gis
     ports:
-      - "${DB_HOST_PORT:-0}:5432"
+      - "${DB_HOST_PORT:-127.0.0.1:5432}:5432"
     volumes:
       - postgis-data:/var/lib/postgresql/data
 
@@ -45,7 +45,7 @@ services:
     image: redis:alpine
     restart: always
     ports:
-      - "${REDIS_HOST_PORT:-0}:6379"
+      - "${REDIS_HOST_PORT:-127.0.0.1:6379}:6379"
     volumes:
       - redis_data:/data
     command: redis-server --requirepass ${REDIS_PASSWORD}
@@ -70,9 +70,10 @@ services:
     restart: always
     command: uv run --no-dev celery -A PharmacyOnDuty flower --port=5555
     ports:
-      - "${FLOWER_HOST_PORT:-0}:5555"
+      - "${FLOWER_HOST_PORT:-127.0.0.1:5555}:5555"
     environment:
       - CELERY_BROKER_URL=redis://:${REDIS_PASSWORD}@redis:6379/0
+      - FLOWER_BASIC_AUTH=${FLOWER_BASIC_AUTH:-}
     depends_on:
       - redis
 


### PR DESCRIPTION
## Summary
- Bind Django, Postgres, Redis, and Flower to loopback by default in the production compose file
- Add `FLOWER_BASIC_AUTH` support so Flower can be protected without changing the app image
- Add repository-level `AGENTS.md` guidance for Codex workflows in this workspace

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added development guidelines and architecture reference.

* **Chores**
  * Updated Docker service port bindings to enable localhost access on standard ports.
  * Added basic authentication configuration option for Flower task monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->