### PR TITLE
♻️ refactor: migrate map directions to Route.computeRoutes

### DIFF
--- a/pharmacies/tests/test_views.py
+++ b/pharmacies/tests/test_views.py
@@ -293,9 +293,8 @@ class TestOtherViews:
         assert response.content == b"console.log('google maps');"
         assert response["Content-Type"] == "text/javascript"
 
-        # The proxy must request the libraries needed by the modern Maps JS
-        # APIs: "marker" for AdvancedMarkerElement, and "routes" for the
-        # modular DirectionsService / DirectionsRenderer imports.
+        # Proxy must load "marker" (AdvancedMarkerElement) and "routes"
+        # (Route.computeRoutes).
         _, call_kwargs = mock_get.call_args
         params = call_kwargs["params"]
         libraries = set(params["libraries"].split(","))

--- a/pharmacies/views.py
+++ b/pharmacies/views.py
@@ -146,10 +146,7 @@ def google_maps_proxy(request: HttpRequest) -> HttpResponse | JsonResponse:
         return HttpResponse("Forbidden", status=403)
 
     endpoint = "https://maps.googleapis.com/maps/api/js"
-    # The "marker" library is required for AdvancedMarkerElement and the
-    # "routes" library provides DirectionsService / DirectionsRenderer via
-    # google.maps.importLibrary("routes"), which is the non-deprecated
-    # modular access pattern for those classes.
+    # "marker" → AdvancedMarkerElement; "routes" → Route.computeRoutes.
     params = {
         "key": settings.GOOGLE_MAPS_API_KEY,
         "libraries": "marker,routes,geometry",

--- a/theme/templates/pharmacies.html
+++ b/theme/templates/pharmacies.html
@@ -91,28 +91,31 @@
 		let map;
 		// Lazily-resolved constructors from the Maps JS modular libraries.
 		let AdvancedMarkerElementCtor;
-		let directionsService;
-		let directionsRenderer;
+		let RouteCtor;
+		let LatLngBoundsCtor;
 		let userLocation;
 		let selectedPharmacy;
 		let markersArray = [];
+		let routePolylines = [];
+		let latestDirectionsId = 0;
 
 		async function initMap(center = { lat: 40.7128, lng: -74.0060 }) {
-			// Load the modular libraries via importLibrary so we don't rely on
-			// the deprecated global google.maps.* namespace access pattern.
-			// "marker" provides AdvancedMarkerElement (the replacement for the
-			// deprecated google.maps.Marker); "routes" provides
-			// DirectionsService / DirectionsRenderer.
+			// Modular importLibrary: marker → AdvancedMarkerElement,
+			// routes → Route.computeRoutes, core → LatLngBounds.
 			const [
 				{ Map },
 				{ AdvancedMarkerElement },
-				{ DirectionsService, DirectionsRenderer },
+				{ Route },
+				{ LatLngBounds },
 			] = await Promise.all([
 				google.maps.importLibrary("maps"),
 				google.maps.importLibrary("marker"),
 				google.maps.importLibrary("routes"),
+				google.maps.importLibrary("core"),
 			]);
 			AdvancedMarkerElementCtor = AdvancedMarkerElement;
+			RouteCtor = Route;
+			LatLngBoundsCtor = LatLngBounds;
 
 			map = new Map(document.getElementById("map"), {
 				center: center,
@@ -128,12 +131,6 @@
 				rotateControl: false,
 				fullscreenControl: false,
 			});
-
-			directionsService = new DirectionsService();
-			directionsRenderer = new DirectionsRenderer({
-				suppressMarkers: true,
-				map: map,
-			});
 		}
 
 		function buildMarkerContent(iconUrl, alt) {
@@ -146,9 +143,30 @@
 			return img;
 		}
 
+		function clearRoutePolylines() {
+			routePolylines.forEach((polyline) => { polyline.setMap(null); });
+			routePolylines = [];
+		}
+
+		function invalidateDirections() {
+			// Invalidate in-flight computeRoutes so a stale response cannot redraw.
+			latestDirectionsId++;
+			clearRoutePolylines();
+		}
+
+		function fitMapToPath(path) {
+			if (!path || path.length === 0) {
+				return;
+			}
+			const bounds = new LatLngBoundsCtor();
+			path.forEach((point) => { bounds.extend(point); });
+			map.fitBounds(bounds);
+		}
+
 		function clearMarkers() {
 			markersArray.forEach((marker) => { marker.map = null; });
 			markersArray = [];
+			invalidateDirections();
 		}
 
 		function addMarkers(point) {
@@ -320,29 +338,42 @@
 		}
 
 		async function showDirectionsToMarker(point, origin) {
-			if (!origin || !point || !directionsService || !directionsRenderer) {
+			if (!origin || !point || !RouteCtor || !map) {
 				return;
 			}
+			const directionsId = ++latestDirectionsId;
 			try {
-				const result = await directionsService.route({
+				const { routes } = await RouteCtor.computeRoutes({
 					origin: { lat: origin.lat, lng: origin.lng },
 					destination: {
 						lat: point.position.lat,
 						lng: point.position.lng,
 					},
-					travelMode: google.maps.TravelMode.DRIVING,
+					travelMode: "DRIVING",
+					fields: ["path"],
 				});
-				// DirectionsRenderer draws the polyline AND auto-fits the
-				// viewport to the route bounds by default.
-				directionsRenderer.setDirections(result);
+				if (directionsId !== latestDirectionsId) {
+					return;
+				}
+				if (!routes?.length) {
+					clearRoutePolylines();
+					return;
+				}
+				clearRoutePolylines();
+				routePolylines = routes[0].createPolylines();
+				routePolylines.forEach((polyline) => { polyline.setMap(map); });
+				fitMapToPath(routes[0].path);
 			} catch (err) {
+				if (directionsId === latestDirectionsId) {
+					clearRoutePolylines();
+				}
 				console.error("Directions request failed:", err);
 			}
 		}
 
 		function getUserLocation(callback) {
 			if (!navigator.geolocation) {
-				console.error("Geolocation is not supported by this browser.");
+				console.warn("Geolocation is not supported by this browser.");
 				callback(null);
 				return;
 			}
@@ -354,7 +385,9 @@
 					});
 				},
 				(error) => {
-					console.error("Error getting location:", error);
+					console.warn(
+						`Geolocation unavailable (code ${error.code}); using default city center.`,
+					);
 					callback(null);
 				},
 				{
@@ -389,6 +422,7 @@
 			if (!Array.isArray(points) || points.length === 0) {
 				$('#selectedPharmacyName').text("Eczane bulunamadı");
 				$('#selectedPharmacyStatus').text("");
+				clearMarkers();
 				console.error("No pharmacy points found.");
 				return;
 			}
@@ -447,9 +481,6 @@
 
 				getUserLocation((location) => {
 					if (!location) {
-						console.warn(
-							"Geolocation failed or blocked. Using default location (Eskişehir).",
-						);
 						userLocation = defaultLocation;
 						if (selectedPharmacy) {
 							addMarkers(selectedPharmacy);


### PR DESCRIPTION
## Summary
- Replace deprecated `DirectionsService` / `DirectionsRenderer` with `Route.computeRoutes` + `createPolylines` and manual `fitBounds`
- Guard overlapping route requests and clear stale polylines when markers reset or results are empty
- Demote expected geolocation failures to a single `console.warn` (Eskişehir fallback unchanged)

## Test plan
- [ ] Hard-refresh pharmacies page — no DirectionsService/DirectionsRenderer deprecation warnings
- [ ] Grant location + click “Yol Tarifi” — polyline draws; custom markers only
- [ ] Switch pharmacies rapidly — only latest route remains (no stacked/stale polylines)
- [ ] Deny location / ad blocker — list still loads for Eskişehir; one quiet geo warn; `ERR_BLOCKED_BY_CLIENT` may still appear from the browser
- [ ] Confirm **Routes API** is enabled on the Google Cloud project for `GOOGLE_MAPS_API_KEY` (and allowlisted if the key is API-restricted)
- [ ] Proxy unit tests still pass (`marker`/`routes`/`geometry` libraries)