### PR TITLE
🐛 fix: handle missing Google Places vicinity

### DIFF
--- a/pharmacies/tests/test_utils.py
+++ b/pharmacies/tests/test_utils.py
@@ -37,6 +37,21 @@ def test_get_map_points_from_fetched_data() -> None:
     assert points[0]["position"] == {"lat": 39.7, "lng": 30.5}
 
 
+def test_get_map_points_from_fetched_data_without_vicinity() -> None:
+    data = [
+        {
+            "geometry": {"location": {"lat": 39.7, "lng": 30.5}},
+            "name": "Test Pharmacy",
+        }
+    ]
+
+    points = get_map_points_from_fetched_data(data)
+
+    assert len(points) == 1
+    assert points[0]["description"] == ""
+    assert points[0]["address"] == ""
+
+
 def test_get_map_points_from_pharmacies() -> None:
     class MockPharmacy:
         def __init__(self) -> None:
@@ -277,7 +292,6 @@ class TestUtilsDB:
             {
                 "name": "Open Eczane",
                 "geometry": {"location": {"lat": 39.7, "lng": 30.5}},
-                "vicinity": "Some address",
             }
         ]
 
@@ -295,3 +309,6 @@ class TestUtilsDB:
 
             assert len(results) == 1
             assert results[0]["title"] == "Open Eczane"
+            assert results[0]["address"] == ""
+            assert results[0]["description"] == ""
+            assert results[0]["travel_distance"] == 100

--- a/pharmacies/utils/utils.py
+++ b/pharmacies/utils/utils.py
@@ -106,15 +106,16 @@ def get_map_points_from_fetched_data(data: list[Any]) -> list[dict[str, Any]]:
     points = []
 
     for pharmacy in data:
+        address = pharmacy.get("vicinity", "")
         point = {
             "position": {
                 "lat": pharmacy["geometry"]["location"]["lat"],
                 "lng": pharmacy["geometry"]["location"]["lng"],
             },
             "title": pharmacy["name"],
-            "description": pharmacy["vicinity"],
+            "description": address,
             "status": "Açık",
-            "address": pharmacy["vicinity"],
+            "address": address,
             "distance": "-",
         }
         points.append(point)


### PR DESCRIPTION
## Summary
- treat the Google Places `vicinity` field as optional
- fall back to an empty pharmacy address instead of returning HTTP 500
- add regression coverage for mapping and nearest-pharmacy lookup

## Root cause
Google Places returned a valid pharmacy result without `vicinity`. Direct indexing raised `KeyError`, which the API converted to `An internal server error occurred.`

## Testing
- `uv run ruff check pharmacies/utils/utils.py pharmacies/tests/test_utils.py`
- `uv run ruff format --check pharmacies/utils/utils.py pharmacies/tests/test_utils.py`
- focused missing-`vicinity` unit test
- focused nearest-open-pharmacy integration test
- pre-commit hooks, including mypy and Tailwind build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of pharmacy data when an address is unavailable.
  * Pharmacy results now display empty address and description fields instead of failing when location details are missing.

* **Tests**
  * Added coverage to verify pharmacy results remain valid and retain travel-distance information when address data is absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->